### PR TITLE
chore: adopt ESLint flat config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    "@typescript-eslint/no-explicit-any": "off"
-  }
-}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
+    rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+    },
     ignores: [
       "node_modules/**",
       ".next/**",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
-  },
+    "lint": "eslint ."
+    },
   "dependencies": {
     "@supabase/supabase-js": "^2.56.1",
     "next": "15.5.2",


### PR DESCRIPTION
## Summary
- remove legacy `.eslintrc.json`
- move `no-explicit-any` rule and ignore list into `eslint.config.mjs`
- run ESLint via `eslint .`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd983df18c8331b5624799a2cf1363