### PR TITLE
chore: enforce lint and type checks in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npx tsc --noEmit

--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Development Workflow
+
+1. Install dependencies with `npm install`.
+2. Start the development server with `npm run dev`.
+3. Before pushing changes, ensure the code passes linting and type checks:
+
+   ```bash
+   npm run lint
+   npx tsc --noEmit
+   ```
+
+These commands are also executed in CI to catch issues early.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,12 +2,12 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   eslint: {
-    // No bloquees el build por errores de ESLint
-    ignoreDuringBuilds: true,
+    // Only ignore ESLint errors outside CI
+    ignoreDuringBuilds: !process.env.CI,
   },
   typescript: {
-    // No bloquees el build por errores de type-checking
-    ignoreBuildErrors: true,
+    // Only ignore type-checking errors outside CI
+    ignoreBuildErrors: !process.env.CI,
   },
 };
 


### PR DESCRIPTION
## Summary
- fail builds on lint and type errors in CI by respecting CI env variable
- add CI workflow running lint and type check
- document expected development workflow

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd9837af908331816316d0d4005416