### PR TITLE
Ensure addNote checks auth and surfaces errors

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -217,7 +217,12 @@ export default function HomePage() {
       alert('Primero crea el cliente');
       return;
     }
-    await addNote(clientId, fieldId, text);
+    try {
+      await addNote(clientId, fieldId, text);
+    } catch (err: any) {
+      alert(err.message || 'Error al agregar la nota');
+      return;
+    }
     const list = await fetchNotes(clientId);
     const byField: Record<string, Note[]> = {};
     list.forEach((n) => {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -59,8 +59,14 @@ export async function fetchNotes(clientId: string) {
 }
 
 export async function addNote(clientId: string, fieldId: string, text: string) {
-  const { data: { user } } = await supabase.auth.getUser();
-  const { error } = await supabase.from('notes')
-    .insert({ client_id: clientId, field_id: fieldId, text, created_by: user!.id });
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    throw new Error('Not authenticated');
+  }
+  const { error } = await supabase
+    .from('notes')
+    .insert({ client_id: clientId, field_id: fieldId, text, created_by: user.id });
   if (error) throw error;
 }


### PR DESCRIPTION
## Summary
- Guard against unauthenticated users when adding notes
- Propagate add note errors to UI for user-friendly alerts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bd982ecc088331a4f7d4f8ebf6c339