### PR TITLE
Cache profile and clear on logout

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -10,6 +10,7 @@ import {
   saveClientRecord,
   addNote,
   fetchNotes,
+  clearProfileCache,
 } from '@/lib/db';
 import { subscribeClientLive } from '@/lib/realtime';
 
@@ -270,6 +271,7 @@ export default function HomePage() {
 
   const logout = async () => {
     await supabase.auth.signOut();
+    clearProfileCache();
     window.location.href = '/login';
   };
 


### PR DESCRIPTION
## Summary
- cache authenticated profile in `lib/db` to avoid redundant lookups
- reuse cached profile in template and client helpers
- clear profile cache when logging out

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bd984aab748331abbf24165a7c6246