### PR TITLE
Set auth cookies after Supabase login

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -269,8 +269,14 @@ export default function HomePage() {
     alert('Ficha guardada en Supabase');
   };
 
+  const clearAuthCookies = () => {
+    document.cookie = 'sb-access-token=; path=/; max-age=0; SameSite=Lax';
+    document.cookie = 'sb-refresh-token=; path=/; max-age=0; SameSite=Lax';
+  };
+
   const logout = async () => {
     await supabase.auth.signOut();
+    clearAuthCookies();
     clearProfileCache();
     window.location.href = '/login';
   };

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import type { Session } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabaseClient';
 
 type Mode = 'login' | 'signup';
@@ -16,6 +17,14 @@ export default function LoginPage() {
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
 
+  const syncSessionCookies = (session: Session | null) => {
+    const expires = session?.expires_at
+      ? new Date(session.expires_at * 1000).toUTCString()
+      : '0';
+    document.cookie = `sb-access-token=${session?.access_token ?? ''}; path=/; expires=${expires}; SameSite=Lax`;
+    document.cookie = `sb-refresh-token=${session?.refresh_token ?? ''}; path=/; expires=${expires}; SameSite=Lax`;
+  };
+
   // On first load, if already authenticated, go to /home (once)
   useEffect(() => {
     let cancelled = false;
@@ -29,6 +38,7 @@ export default function LoginPage() {
 
     // Also listen for auth state changes while this page is open
     const { data: sub } = supabase.auth.onAuthStateChange((_ev, session) => {
+      syncSessionCookies(session);
       if (session) router.replace('/home'); // <-- never redirect back to /login
     });
 
@@ -69,7 +79,10 @@ export default function LoginPage() {
 
       // Intento de sesión inmediata (evita esperar al listener)
       const { data } = await supabase.auth.getSession();
-      if (data.session) router.replace('/home');
+      if (data.session) {
+        syncSessionCookies(data.session);
+        router.replace('/home');
+      }
     } catch (e: any) {
       setMsg(`❌ ${e?.message ?? 'Error al autenticar'}`);
     } finally {


### PR DESCRIPTION
## Summary
- sync Supabase session tokens to cookies after authentication
- clear auth cookies on logout to avoid stale sessions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda988eda48331934b7c496de557df