### PR TITLE
Set auth cookies after Supabase login

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -269,8 +269,14 @@ export default function HomePage() {
     alert('Ficha guardada en Supabase');
   };
 
+  const clearAuthCookies = () => {
+    document.cookie = 'sb-access-token=; path=/; max-age=0; SameSite=Lax';
+    document.cookie = 'sb-refresh-token=; path=/; max-age=0; SameSite=Lax';
+  };
+
   const logout = async () => {
     await supabase.auth.signOut();
+    clearAuthCookies();
     clearProfileCache();
     window.location.href = '/login';
   };


### PR DESCRIPTION
## Summary
- sync Supabase session tokens to cookies after authentication
- clear auth cookies on logout to avoid stale sessions
- ensure existing sessions also sync cookies before redirect to avoid login/home redirect loop

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda988eda48331934b7c496de557df