### PR TITLE
Add dashboard landing with client list and sidebar

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+import { fetchClients } from '@/lib/clients';
+import { createClient } from '@/lib/db';
+import type { ClientRow } from '@/lib/clients';
+
+export default function DashboardPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [clients, setClients] = useState<ClientRow[]>([]);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getUser();
+      if (!data.user) {
+        window.location.href = '/login';
+        return;
+      }
+      setEmail(data.user.email ?? null);
+      try {
+        const rows = await fetchClients();
+        setClients(rows);
+      } catch (e: any) {
+        setMsg(e?.message ?? 'No se pudieron cargar las fichas');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  async function onCreate() {
+    try {
+      const name = prompt('Nombre del cliente') || 'Sin nombre';
+      const id = await createClient(name, 'Lead');
+      router.push(`/home?client=${id}`);
+    } catch (e: any) {
+      setMsg(e?.message ?? 'No se pudo crear el cliente');
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-slate-800">Tus fichas</h1>
+            {email && <p className="text-sm text-slate-600">Hola, {email}</p>}
+          </div>
+          <button
+            className="rounded-lg bg-sky-600 text-white px-4 py-2 hover:bg-sky-700"
+            onClick={onCreate}
+            aria-label="Crear nuevo cliente"
+          >
+            Crear nuevo cliente
+          </button>
+        </div>
+
+        {msg && <p className="mt-3 text-sm text-rose-600">{msg}</p>}
+
+        {loading ? (
+          <div className="mt-8 text-slate-600">Cargando…</div>
+        ) : clients.length === 0 ? (
+          <div className="mt-8 text-slate-600">Aún no hay fichas. Crea la primera.</div>
+        ) : (
+          <div className="mt-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {clients.map((c) => (
+              <button
+                key={c.id}
+                onClick={() => router.push(`/home?client=${c.id}`)}
+                className="text-left rounded-2xl border border-slate-200 bg-white p-4 hover:shadow-sm"
+                aria-label={`Abrir cliente ${c.name}`}
+              >
+                <div className="font-medium text-slate-800">{c.name}</div>
+                <div className="mt-1 text-xs text-slate-500">
+                  {c.tag} • {new Date(c.created_at).toLocaleDateString()}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -167,7 +167,7 @@ function FieldCard({
   );
 }
 
-export default function HomePage() {
+export default function HomePage({ searchParams }: { searchParams: { client?: string } }) {
   const router = useRouter();
   // Protección de ruta: esperamos conocer la sesión antes de renderizar el dashboard
   const [ready, setReady] = useState(false);
@@ -209,6 +209,10 @@ export default function HomePage() {
   const [userEmail, setUserEmail] = useState<string | null>(null);
 
   const unsub = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (searchParams?.client) setClientId(searchParams.client);
+  }, [searchParams?.client]);
 
   useEffect(() => {
     (async () => {
@@ -273,15 +277,24 @@ export default function HomePage() {
   useEffect(() => {
     if (!clientId) return;
 
+    (async () => {
+      const list = await fetchNotes(clientId);
+      const byField: Record<string, Note[]> = {};
+      list.forEach((n: any) => {
+        (byField[n.field_id] ||= []).push(n as any);
+      });
+      setNotesState(byField);
+    })();
+
     const u = subscribeClientLive(
       clientId,
       () => {},
       async () => {
         const list = await fetchNotes(clientId);
         const byField: Record<string, Note[]> = {};
-          list.forEach((n: any) => {
-            (byField[n.field_id] ||= []).push(n as any);
-          });
+        list.forEach((n: any) => {
+          (byField[n.field_id] ||= []).push(n as any);
+        });
         setNotesState(byField);
       }
     );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -22,7 +22,7 @@ export default function LoginPage() {
     (async () => {
       const { data } = await supabase.auth.getSession();
       if (!cancelled && data.session) {
-        router.replace('/home');
+        router.replace('/dashboard');
       } else if (!cancelled) {
         setReady(true);
       }
@@ -42,14 +42,14 @@ export default function LoginPage() {
         const { data, error } = await supabase.auth.signUp({ email, password: pass });
         if (error) throw error;
         if (data.session) {
-          router.replace('/home');
+          router.replace('/dashboard');
           return;
         }
       } else {
         const { data, error } = await supabase.auth.signInWithPassword({ email, password: pass });
         if (error) throw error;
         if (data.session) {
-          router.replace('/home');
+          router.replace('/dashboard');
           return;
         }
       }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -21,7 +21,7 @@ export default function Signup() {
     const { data, error: inErr } = await supabase.auth.signInWithPassword({ email, password: pass });
     if (inErr) return setMsg('❌ ' + inErr.message);
 
-    if (data.session) router.replace('/home');
+    if (data.session) router.replace('/dashboard');
   }
 
   return (

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const items = [
+  { href: '/dashboard', label: 'Fichas' },
+  { href: '#', label: 'Plantillas' },
+  { href: '#', label: 'Reportes' },
+  { href: '#', label: 'Ajustes' },
+];
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  return (
+    <aside className="w-60 shrink-0 bg-white border-r border-slate-200 min-h-screen p-4">
+      <div className="text-lg font-semibold text-slate-800 mb-4">Corkboard CRM</div>
+      <nav className="space-y-1">
+        {items.map((it) => {
+          const active = pathname === it.href;
+          return (
+            <Link
+              key={it.label}
+              href={it.href}
+              className={`block rounded-lg px-3 py-2 text-sm ${
+                active ? 'bg-slate-100 text-slate-900' : 'text-slate-700 hover:bg-slate-50'
+              }`}
+            >
+              {it.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,0 +1,12 @@
+import { supabase } from './supabaseClient';
+
+export type ClientRow = { id: string; name: string; tag: string; created_at: string };
+
+export async function fetchClients(): Promise<ClientRow[]> {
+  const { data, error } = await supabase
+    .from('clients')
+    .select('id,name,tag,created_at')
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return data ?? [];
+}


### PR DESCRIPTION
## Summary
- implement `/dashboard` page showing user email, sidebar, clients grid, and create-client button
- redirect auth flows to new dashboard
- allow `/home` to load a client via `searchParams` and fetch its notes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc0a51cd883318e6567e38ff51ed4