### PR TITLE
feat: add reusable client creation modal

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
+import ModalCreateClient from '@/components/ModalCreateClient';
 import { fetchClients } from '@/lib/clients';
 import { createClient } from '@/lib/db';
 import type { ClientRow } from '@/lib/clients';
@@ -14,6 +15,7 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [clients, setClients] = useState<ClientRow[]>([]);
   const [msg, setMsg] = useState<string | null>(null);
+  const [openCreate, setOpenCreate] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -34,58 +36,60 @@ export default function DashboardPage() {
     })();
   }, []);
 
-  async function onCreate() {
-    try {
-      const name = prompt('Nombre del cliente') || 'Sin nombre';
-      const id = await createClient(name, 'Lead');
-      router.push(`/home?client=${id}`);
-    } catch (e: any) {
-      setMsg(e?.message ?? 'No se pudo crear el cliente');
-    }
+  async function onCreate(name: string, tag: string) {
+    const id = await createClient(name, tag);
+    router.push(`/home?client=${id}`);
   }
 
   return (
-    <div className="min-h-screen bg-slate-50 flex">
-      <Sidebar />
-      <main className="flex-1 p-6">
-        <div className="flex items-center justify-between">
+    <>
+      <div className="min-h-screen bg-slate-50 flex">
+        <Sidebar />
+        <main className="flex-1 p-6">
+          <div className="flex items-center justify-between">
           <div>
             <h1 className="text-xl font-semibold text-slate-800">Tus fichas</h1>
             {email && <p className="text-sm text-slate-600">Hola, {email}</p>}
           </div>
           <button
             className="rounded-lg bg-sky-600 text-white px-4 py-2 hover:bg-sky-700"
-            onClick={onCreate}
+            onClick={() => setOpenCreate(true)}
             aria-label="Crear nuevo cliente"
           >
             Crear nuevo cliente
           </button>
-        </div>
-
-        {msg && <p className="mt-3 text-sm text-rose-600">{msg}</p>}
-
-        {loading ? (
-          <div className="mt-8 text-slate-600">Cargando…</div>
-        ) : clients.length === 0 ? (
-          <div className="mt-8 text-slate-600">Aún no hay fichas. Crea la primera.</div>
-        ) : (
-          <div className="mt-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {clients.map((c) => (
-              <button
-                key={c.id}
-                onClick={() => router.push(`/home?client=${c.id}`)}
-                className="text-left rounded-2xl border border-slate-200 bg-white p-4 hover:shadow-sm"
-                aria-label={`Abrir cliente ${c.name}`}
-              >
-                <div className="font-medium text-slate-800">{c.name}</div>
-                <div className="mt-1 text-xs text-slate-500">
-                  {c.tag} • {new Date(c.created_at).toLocaleDateString()}
-                </div>
-              </button>
-            ))}
           </div>
-        )}
-      </main>
-    </div>
+
+          {msg && <p className="mt-3 text-sm text-rose-600">{msg}</p>}
+
+          {loading ? (
+            <div className="mt-8 text-slate-600">Cargando…</div>
+          ) : clients.length === 0 ? (
+            <div className="mt-8 text-slate-600">Aún no hay fichas. Crea la primera.</div>
+          ) : (
+            <div className="mt-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {clients.map((c) => (
+                <button
+                  key={c.id}
+                  onClick={() => router.push(`/home?client=${c.id}`)}
+                  className="text-left rounded-2xl border border-slate-200 bg-white p-4 hover:shadow-sm"
+                  aria-label={`Abrir cliente ${c.name}`}
+                >
+                  <div className="font-medium text-slate-800">{c.name}</div>
+                  <div className="mt-1 text-xs text-slate-500">
+                    {c.tag} • {new Date(c.created_at).toLocaleDateString()}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </main>
+      </div>
+      <ModalCreateClient
+        open={openCreate}
+        onClose={() => setOpenCreate(false)}
+        onCreate={onCreate}
+      />
+    </>
   );
 }

--- a/components/ModalCreateClient.tsx
+++ b/components/ModalCreateClient.tsx
@@ -1,0 +1,79 @@
+'use client';
+import { useState } from 'react';
+
+export default function ModalCreateClient({
+  open,
+  onClose,
+  onCreate,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCreate: (name: string, tag: string) => Promise<void> | void;
+}) {
+  const [name, setName] = useState('');
+  const [tag, setTag] = useState<'Lead' | 'MQL' | 'SQL' | 'Won' | 'Lost'>('Lead');
+  const [loading, setLoading] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  async function submit() {
+    setMsg(null);
+    setLoading(true);
+    try {
+      await onCreate(name.trim() || 'Sin nombre', tag);
+      onClose();
+      setName('');
+    } catch (e: any) {
+      setMsg(e?.message ?? 'No se pudo crear el cliente');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-slate-900/40" onClick={onClose} />
+      <div className="relative w-full max-w-md rounded-2xl bg-white p-5 shadow-lg border border-slate-200">
+        <h3 className="text-lg font-semibold text-slate-800">Crear nuevo cliente</h3>
+        <div className="mt-4 space-y-3">
+          <div>
+            <label className="text-sm text-slate-600">Nombre</label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-400"
+              placeholder="Ej: Juan Pérez"
+            />
+          </div>
+          <div>
+            <label className="text-sm text-slate-600">Estado</label>
+            <select
+              value={tag}
+              onChange={(e) => setTag(e.target.value as any)}
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-400"
+            >
+              {['Lead', 'MQL', 'SQL', 'Won', 'Lost'].map((t) => (
+                <option key={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+          {msg && <p className="text-sm text-rose-600">{msg}</p>}
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button className="px-3 py-2 rounded-lg border hover:bg-slate-50" onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            onClick={submit}
+            disabled={loading}
+            className="px-3 py-2 rounded-lg bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-60"
+          >
+            {loading ? 'Creando…' : 'Crear'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable ModalCreateClient component for entering client name and status
- integrate the modal into dashboard and remove prompt-based creation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc37acb348331b533b8afb247dfee