### PR TITLE
Implement dashboard client grid, query-driven home, and auth guards

### DIFF
--- a/app/brokers/page.tsx
+++ b/app/brokers/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+
+export default function BrokersPage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      if (!data.user) {
+        router.replace('/login');
+      } else {
+        setReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-slate-50">
+        <div className="text-slate-600">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Comparador de Brokers</h1>
+        <p className="mt-4 text-slate-600">Próximamente…</p>
+      </main>
+    </div>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
 import ModalCreateClient from '@/components/ModalCreateClient';
 import { fetchClients } from '@/lib/clients';
-import { createClient } from '@/lib/db';
+import { createClient, logout } from '@/lib/db';
 import type { ClientRow } from '@/lib/clients';
 
 export default function DashboardPage() {
@@ -21,7 +21,7 @@ export default function DashboardPage() {
     (async () => {
       const { data } = await supabase.auth.getUser();
       if (!data.user) {
-        window.location.href = '/login';
+        router.replace('/login');
         return;
       }
       setEmail(data.user.email ?? null);
@@ -34,7 +34,7 @@ export default function DashboardPage() {
         setLoading(false);
       }
     })();
-  }, []);
+  }, [router]);
 
   async function onCreate(name: string, tag: string) {
     const id = await createClient(name, tag);
@@ -47,17 +47,25 @@ export default function DashboardPage() {
         <Sidebar />
         <main className="flex-1 p-6">
           <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-xl font-semibold text-slate-800">Tus fichas</h1>
-            {email && <p className="text-sm text-slate-600">Hola, {email}</p>}
-          </div>
-          <button
-            className="rounded-lg bg-sky-600 text-white px-4 py-2 hover:bg-sky-700"
-            onClick={() => setOpenCreate(true)}
-            aria-label="Crear nuevo cliente"
-          >
-            Crear nuevo cliente
-          </button>
+            <div>
+              <h1 className="text-xl font-semibold text-slate-800">Tus fichas</h1>
+              {email && <p className="text-sm text-slate-600">Hola, {email}</p>}
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                className="rounded-lg bg-sky-600 text-white px-4 py-2 hover:bg-sky-700"
+                onClick={() => setOpenCreate(true)}
+                aria-label="Crear nuevo cliente"
+              >
+                Crear nuevo cliente
+              </button>
+              <button
+                className="rounded-lg border bg-white px-4 py-2 hover:bg-slate-50"
+                onClick={logout}
+              >
+                Salir
+              </button>
+            </div>
           </div>
 
           {msg && <p className="mt-3 text-sm text-rose-600">{msg}</p>}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      if (!data.user) {
+        router.replace('/login');
+      } else {
+        setReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-slate-50">
+        <div className="text-slate-600">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Perfil</h1>
+        <p className="mt-4 text-slate-600">Próximamente…</p>
+      </main>
+    </div>
+  );
+}

--- a/app/scripts/page.tsx
+++ b/app/scripts/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+
+export default function ScriptsPage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      if (!data.user) {
+        router.replace('/login');
+      } else {
+        setReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-slate-50">
+        <div className="text-slate-600">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Guiones</h1>
+        <p className="mt-4 text-slate-600">Próximamente…</p>
+      </main>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+
+export default function SettingsPage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      if (!data.user) {
+        router.replace('/login');
+      } else {
+        setReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-slate-50">
+        <div className="text-slate-600">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Ajustes</h1>
+        <p className="mt-4 text-slate-600">Próximamente…</p>
+      </main>
+    </div>
+  );
+}

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+import Sidebar from '@/components/Sidebar';
+
+export default function TemplatesPage() {
+  const router = useRouter();
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    supabase.auth.getUser().then(({ data }) => {
+      if (!active) return;
+      if (!data.user) {
+        router.replace('/login');
+      } else {
+        setReady(true);
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [router]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-slate-50">
+        <div className="text-slate-600">Cargando…</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Plantillas</h1>
+        <p className="mt-4 text-slate-600">Próximamente…</p>
+      </main>
+    </div>
+  );
+}

--- a/components/ModalText.tsx
+++ b/components/ModalText.tsx
@@ -1,0 +1,65 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export default function ModalText({
+  open,
+  title,
+  placeholder,
+  defaultValue = '',
+  area = false,
+  onClose,
+  onSubmit,
+}: {
+  open: boolean;
+  title: string;
+  placeholder?: string;
+  defaultValue?: string;
+  area?: boolean;
+  onClose: () => void;
+  onSubmit: (val: string) => void | Promise<void>;
+}) {
+  const [value, setValue] = useState(defaultValue);
+  useEffect(() => {
+    if (open) setValue(defaultValue);
+  }, [open, defaultValue]);
+  if (!open) return null;
+  async function submit() {
+    await onSubmit(value);
+    onClose();
+  }
+  const Input = area ? (
+    <textarea
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      className="mt-4 w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-400"
+      placeholder={placeholder}
+    />
+  ) : (
+    <input
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+      className="mt-4 w-full rounded-lg border border-slate-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-sky-400"
+      placeholder={placeholder}
+    />
+  );
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-slate-900/40" onClick={onClose} />
+      <div className="relative w-full max-w-md rounded-2xl bg-white p-5 shadow-lg border border-slate-200">
+        <h3 className="text-lg font-semibold text-slate-800">{title}</h3>
+        {Input}
+        <div className="mt-5 flex justify-end gap-2">
+          <button className="px-3 py-2 rounded-lg border hover:bg-slate-50" onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            onClick={submit}
+            className="px-3 py-2 rounded-lg bg-sky-600 text-white hover:bg-sky-700"
+          >
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -104,3 +104,11 @@ export async function addNote(clientId: string, fieldId: string, text: string) {
     .insert({ client_id: clientId, field_id: fieldId, text, created_by: user.id });
   if (error) throw error;
 }
+
+export async function logout() {
+  await supabase.auth.signOut();
+  document.cookie = 'sb-access-token=; path=/; max-age=0';
+  document.cookie = 'sb-refresh-token=; path=/; max-age=0';
+  clearProfileCache();
+  window.location.href = '/login';
+}


### PR DESCRIPTION
## Summary
- Protect dashboard and home routes and display user-specific data
- Replace browser prompts with custom modals and add universal logout helper
- Scaffold sidebar routes (templates, scripts, profile, brokers, settings)

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc5a1db7c833187df3093d8c27285