### PR TITLE
fix: ensure supabase client is typed

### DIFF
--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 
 // Read and validate required Supabase environment variables.
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -8,7 +8,7 @@ if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   console.warn('Supabase env vars are not fully defined. Auth will be disabled.');
 }
 
-export const supabase =
+export const supabase: SupabaseClient =
   SUPABASE_URL && SUPABASE_ANON_KEY
     ? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
         auth: {
@@ -16,4 +16,4 @@ export const supabase =
           autoRefreshToken: false,
         },
       })
-    : ({} as any);
+    : ({} as SupabaseClient);


### PR DESCRIPTION
## Summary
- type Supabase client to avoid implicit any errors in auth calls

## Testing
- `npm run lint`
- `npm test`
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch `Geist` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc7c0871c8331b17a6c6d3b17f9ec