### PR TITLE
Fix client creation error in Supabase insert

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -67,7 +67,6 @@ export async function createClient(name: string, tag: string) {
     .from('clients')
     .insert([{ org_id, name, tag, created_by: userId }])
     .select('id')
-    .limit(1)
     .single();
 
   if (error) throw error;


### PR DESCRIPTION
## Summary
- remove redundant `limit` from client insert so Supabase can return a single row

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bdd97ab5088331bb3677b63e42a905