### PR TITLE
feat: simplify client view with new toolbar and collapsible recommendations

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -4,15 +4,7 @@ export const dynamic = 'force-dynamic';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
-import {
-  fetchTemplates,
-  createTemplate,
-  createClient,
-  saveClientRecord,
-  addNote,
-  fetchNotes,
-  logout,
-} from '@/lib/db';
+import { fetchTemplates, addNote, fetchNotes, deleteClient } from '@/lib/db';
 import ModalText from '@/components/ModalText';
 import { subscribeClientLive } from '@/lib/realtime';
 import { computeRecommendations } from '@/lib/recommendations';
@@ -197,17 +189,19 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const [tpl, setTpl] = useState<Template | null>(null);
 
   const [clientId, setClientId] = useState<string>('');
-  const [clientName, setClientName] = useState('');
-  const [clientTag, setClientTag] = useState('Lead');
 
   const [answers, setAnswers] = useState<Answers>({});
   const [notes, setNotesState] = useState<Record<string, Note[]>>({});
 
   const [noteField, setNoteField] = useState<string | null>(null);
-  const [openTplName, setOpenTplName] = useState(false);
-
   const [zoom, setZoom] = useState(1);
-  const [userEmail, setUserEmail] = useState<string | null>(null);
+
+  const [tplMenuOpen, setTplMenuOpen] = useState(false);
+  const [addFieldOpen, setAddFieldOpen] = useState(false);
+  const [newLabel, setNewLabel] = useState('');
+  const [newType, setNewType] = useState<FieldType>('text');
+  const [newOptions, setNewOptions] = useState('');
+  const [recsOpen, setRecsOpen] = useState(true);
 
   const unsub = useRef<(() => void) | null>(null);
 
@@ -217,8 +211,6 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
 
   useEffect(() => {
     (async () => {
-      const { data: u } = await supabase.auth.getUser();
-      setUserEmail(u.user?.email ?? null);
       const list = await fetchTemplates();
       setTemplates(list as any);
       if (list.length) setTpl(list[0] as any);
@@ -234,13 +226,12 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   }, [tpl]);
 
   const recommendations = useMemo(() => computeRecommendations(answers, labelMap), [answers, labelMap]);
-  const totalScore = useMemo(() => recommendations.reduce((a, b) => a + b.score, 0), [recommendations]);
 
   const updateAnswer = (id: string, val: any) => setAnswers((prev) => ({ ...prev, [id]: val }));
 
   const addNoteLocalAndRemote = async (fieldId: string, text: string) => {
     if (!clientId) {
-      alert('Primero crea el cliente');
+      alert('Cliente no válido');
       return;
     }
     try {
@@ -255,20 +246,6 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
       (byField[n.field_id] ||= []).push(n as any);
     });
     setNotesState(byField);
-  };
-
-  const saveTemplateBtn = () => {
-    if (!tpl) return;
-    setOpenTplName(true);
-  };
-
-  const createClientBtn = async () => {
-    unsub.current?.();
-    unsub.current = null;
-    const name = clientName.trim() || 'Sin nombre';
-    const id = await createClient(name, clientTag);
-    setClientId(id);
-    alert(`Cliente creado (${id})`);
   };
 
   useEffect(() => {
@@ -302,19 +279,6 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
     };
   }, [clientId]);
 
-  const saveRecordBtn = async () => {
-    if (!tpl) {
-      alert('Elige plantilla');
-      return;
-    }
-    if (!clientId) {
-      alert('Crea el cliente primero');
-      return;
-    }
-    await saveClientRecord(clientId, tpl.id, answers, totalScore, recommendations);
-    alert('Ficha guardada en Supabase');
-  };
-
   const corkBg: React.CSSProperties = {
     backgroundImage:
       'radial-gradient(#c7a574 1px, transparent 1px), radial-gradient(#c7a574 1px, transparent 1px)',
@@ -329,49 +293,79 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
       </div>
     );
   }
-
   return (
     <div className="min-h-screen w-full bg-slate-100">
-      <div className="sticky top-0 z-20 backdrop-blur bg-white/70 border-b border-slate-200">
-        <div className="mx-auto max-w-[1400px] px-4 py-3 flex items-center gap-3">
-          <div className="font-semibold text-slate-800 text-lg">Corkboard CRM</div>
-          <div className="hidden md:flex items-center gap-2">
-            <input
-              className="rounded-lg border px-2 py-1"
-              placeholder="Nombre del cliente"
-              value={clientName}
-              onChange={(e) => setClientName(e.target.value)}
-            />
-            <select className="rounded-lg border px-2 py-1" value={clientTag} onChange={(e) => setClientTag(e.target.value)}>
-              {['Lead', 'MQL', 'SQL', 'Won', 'Lost'].map((t) => (
-                <option key={t}>{t}</option>
-              ))}
-            </select>
-            <span className="text-sm text-slate-600">Score:</span>
-            <Badge>{totalScore}</Badge>
+      <div className="sticky top-0 z-20 flex justify-end p-2 bg-white/70 backdrop-blur border-b border-slate-200">
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-slate-600">Zoom</label>
+          <input
+            type="range"
+            min={0.7}
+            max={1.2}
+            step={0.05}
+            value={zoom}
+            onChange={(e) => setZoom(Number(e.target.value))}
+          />
+          <button
+            className="px-3 py-1.5 rounded-xl border border-red-200 text-red-600 hover:bg-red-50"
+            onClick={async () => {
+              if (!clientId) return;
+              if (confirm('¿Eliminar este cliente?')) {
+                try {
+                  await deleteClient(clientId);
+                  router.push('/dashboard');
+                } catch (err: any) {
+                  alert(err.message || 'Error al eliminar el cliente');
+                }
+              }
+            }}
+          >
+            Eliminar cliente
+          </button>
+          <button
+            className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+            onClick={() => router.push('/dashboard')}
+          >
+            Salir
+          </button>
+          <div className="relative">
+            <button
+              className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+              onClick={() => setTplMenuOpen((o) => !o)}
+            >
+              Cargar plantilla
+            </button>
+            {tplMenuOpen && (
+              <div className="absolute right-0 mt-2 w-48 bg-white border rounded-xl shadow-md z-10">
+                {templates.map((t) => (
+                  <button
+                    key={t.id}
+                    onClick={() => {
+                      setTpl(t as any);
+                      setTplMenuOpen(false);
+                    }}
+                    className="block w-full text-left px-3 py-2 hover:bg-slate-50"
+                  >
+                    {t.name}
+                  </button>
+                ))}
+              </div>
+            )}
           </div>
-          <div className="ml-auto flex items-center gap-2">
-            {userEmail && <span className="text-sm text-slate-600">Hola, {userEmail}</span>}
-            <label className="text-sm text-slate-600">Zoom</label>
-            <input type="range" min={0.7} max={1.2} step={0.05} value={zoom} onChange={(e) => setZoom(Number(e.target.value))} />
-            <button className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50" onClick={saveTemplateBtn}>
-              Guardar plantilla
-            </button>
-            <button className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50" onClick={createClientBtn}>
-              Crear cliente
-            </button>
-            <button className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50" onClick={saveRecordBtn}>
-              Guardar ficha
-            </button>
-            <button className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50" onClick={logout}>
-              Salir
-            </button>
-          </div>
+          <button
+            className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700"
+            onClick={() => setAddFieldOpen(true)}
+          >
+            Agregar pregunta
+          </button>
         </div>
       </div>
 
       <div className="mx-auto max-w-[1400px] px-4 py-6 grid grid-cols-12 gap-4">
-        <div className="col-span-8 rounded-3xl p-4 border border-slate-200 shadow-sm" style={{ ...corkBg }}>
+        <div
+          className={`${recsOpen ? 'col-span-9' : 'col-span-12'} relative rounded-3xl p-4 border border-slate-200 shadow-sm transition-all duration-300`}
+          style={{ ...corkBg }}
+        >
           <div
             className="grid gap-3"
             style={{
@@ -391,55 +385,36 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
               />
             ))}
           </div>
+          <button
+            onClick={() => setRecsOpen((o) => !o)}
+            className="absolute top-4 -right-4 w-8 h-8 rounded-full shadow bg-white flex items-center justify-center"
+          >
+            {recsOpen ? '<' : '>'}
+          </button>
         </div>
 
-        <div className="col-span-4 flex flex-col gap-4">
-          <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold text-slate-800">Recomendaciones</h3>
-              <Badge>{recommendations.length}</Badge>
-            </div>
-            <p className="text-sm text-slate-600 mt-1">Se actualizan según tus respuestas.</p>
-            <div className="mt-3 space-y-2">
-              {recommendations.map((r) => (
-                <div key={r.id} className="rounded-xl border p-3 bg-slate-50">
-                  <div className="flex items-center justify-between">
-                    <div className="font-medium text-slate-800">{r.title}</div>
-                    <Badge>+{r.score}</Badge>
-                  </div>
+        {recsOpen && (
+          <div className="col-span-3 transition-all duration-300">
+            <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
+              <div className="flex items-center justify-between">
+                <h3 className="font-semibold text-slate-800">Recomendaciones</h3>
+                <Badge>{recommendations.length}</Badge>
+              </div>
+              <p className="text-sm text-slate-600 mt-1">Se actualizan según tus respuestas.</p>
+              <div className="mt-3 space-y-2">
+                {recommendations.map((r) => (
+                  <div key={r.id} className="rounded-xl border p-3 bg-slate-50">
+                    <div className="flex items-center justify-between">
+                      <div className="font-medium text-slate-800">{r.title}</div>
+                      <Badge>+{r.score}</Badge>
+                    </div>
                     <div className="text-xs text-slate-600 mt-1">{r.reason}</div>
-                </div>
-              ))}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-
-          <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
-            <h3 className="font-semibold text-slate-800">Plantillas</h3>
-            <p className="text-sm text-slate-600">Cámbialas al vuelo (desde Supabase).</p>
-            <div className="mt-2 grid grid-cols-2 gap-2">
-              {templates.map((t) => (
-                <button
-                  key={t.id}
-                  onClick={() => setTpl(t as any)}
-                  className={`text-left rounded-xl border p-2 hover:bg-slate-50 ${
-                    tpl?.id === t.id ? 'border-sky-600 ring-1 ring-sky-300' : ''
-                  }`}
-                >
-                  <div className="font-medium text-slate-800 truncate">{t.name}</div>
-                  <div className="text-[11px] text-slate-500">{(t.fields || []).length} preguntas</div>
-                </button>
-              ))}
-            </div>
-          </div>
-
-          <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
-            <h3 className="font-semibold text-slate-800">Consejos</h3>
-            <ul className="list-disc list-inside text-sm text-slate-600 space-y-1">
-              <li>Crea el cliente y guarda su ficha para registrar respuestas.</li>
-              <li>Usa tarjetas <b>note</b> para stickies y quedan guardadas.</li>
-            </ul>
-          </div>
-        </div>
+        )}
       </div>
 
       <footer className="py-6 text-center text-xs text-slate-500">Corkboard CRM • Supabase</footer>
@@ -455,19 +430,86 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
         }}
       />
 
-      <ModalText
-        open={openTplName}
-        title="Nombre de la plantilla"
-        defaultValue={tpl?.name || ''}
-        onClose={() => setOpenTplName(false)}
-        onSubmit={async (name) => {
-          if (!tpl) return;
-          await createTemplate(name.trim() || tpl.name, tpl.fields);
-          const list = await fetchTemplates();
-          setTemplates(list as any);
-          alert('Plantilla guardada en Supabase');
-        }}
-      />
+      {addFieldOpen && (
+        <div className="fixed inset-0 bg-black/50 z-50 grid place-items-center">
+          <div className="bg-white rounded-xl p-4 w-80 space-y-3">
+            <h2 className="text-lg font-semibold text-slate-800">Agregar pregunta</h2>
+            <div className="space-y-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-sm text-slate-600">Label</label>
+                <input
+                  className="rounded-lg border border-slate-200 p-2"
+                  value={newLabel}
+                  onChange={(e) => setNewLabel(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-sm text-slate-600">Tipo</label>
+                <select
+                  className="rounded-lg border border-slate-200 p-2"
+                  value={newType}
+                  onChange={(e) => setNewType(e.target.value as FieldType)}
+                >
+                  <option value="text">text</option>
+                  <option value="number">number</option>
+                  <option value="select">select</option>
+                  <option value="multiselect">multiselect</option>
+                  <option value="currency">currency</option>
+                  <option value="note">note</option>
+                </select>
+              </div>
+              {(newType === 'select' || newType === 'multiselect') && (
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm text-slate-600">Opciones (separadas por coma)</label>
+                  <textarea
+                    className="rounded-lg border border-slate-200 p-2"
+                    value={newOptions}
+                    onChange={(e) => setNewOptions(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+                onClick={() => setAddFieldOpen(false)}
+              >
+                Cancelar
+              </button>
+              <button
+                className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700"
+                onClick={() => {
+                  if (!newLabel.trim() || !newType) {
+                    alert('Label y tipo requeridos');
+                    return;
+                  }
+                  const id = crypto.randomUUID();
+                  const maxY = tpl?.fields.reduce((m, f) => Math.max(m, f.y + f.h), 0) || 0;
+                  const field: Field = {
+                    id,
+                    label: newLabel.trim(),
+                    type: newType,
+                    x: 1,
+                    y: maxY + 1,
+                    w: 3,
+                    h: 2,
+                    ...(newType === 'select' || newType === 'multiselect'
+                      ? { options: newOptions.split(',').map((s) => s.trim()).filter(Boolean) }
+                      : {}),
+                  };
+                  setTpl((prev) => (prev ? { ...prev, fields: [...prev.fields, field] } : prev));
+                  setAddFieldOpen(false);
+                  setNewLabel('');
+                  setNewType('text');
+                  setNewOptions('');
+                }}
+              >
+                Guardar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -110,6 +110,18 @@ export async function addNote(clientId: string, fieldId: string, text: string) {
   return data;
 }
 
+export async function deleteClient(clientId: string) {
+  const { error: notesError } = await supabase.from('notes').delete().eq('client_id', clientId);
+  if (notesError) throw new Error(notesError.message);
+  const { error: recordsError } = await supabase
+    .from('client_records')
+    .delete()
+    .eq('client_id', clientId);
+  if (recordsError) throw new Error(recordsError.message);
+  const { error } = await supabase.from('clients').delete().eq('id', clientId).single();
+  if (error) throw new Error(error.message);
+}
+
 export async function logout() {
   await supabase.auth.signOut();
   document.cookie = 'sb-access-token=; path=/; max-age=0';


### PR DESCRIPTION
## Summary
- Replace old header with right-aligned toolbar including zoom slider, delete client, exit, template loader, and add-question actions
- Expand canvas and add toggleable recommendations panel
- Add modal for creating new fields and backend helper to delete clients

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde9c0119c8331a20fff484e509adb