### PR TITLE
feat: seed default templates and add date field

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
 import ModalCreateClient from '@/components/ModalCreateClient';
 import { fetchClients } from '@/lib/clients';
-import { createClient, logout } from '@/lib/db';
+import { createClient, logout, ensureDefaultTemplates, getMyProfile } from '@/lib/db';
 import type { ClientRow } from '@/lib/clients';
 
 export default function DashboardPage() {
@@ -26,6 +26,8 @@ export default function DashboardPage() {
       }
       setEmail(data.user.email ?? null);
       try {
+        const { org_id } = await getMyProfile();
+        await ensureDefaultTemplates(org_id);
         const rows = await fetchClients();
         setClients(rows);
       } catch (e: any) {

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -9,7 +9,14 @@ import ModalText from '@/components/ModalText';
 import { subscribeClientLive } from '@/lib/realtime';
 import { computeRecommendations } from '@/lib/recommendations';
 
-type FieldType = 'text' | 'number' | 'select' | 'multiselect' | 'currency' | 'note';
+type FieldType =
+  | 'text'
+  | 'number'
+  | 'select'
+  | 'multiselect'
+  | 'currency'
+  | 'note'
+  | 'date';
 
 type Field = {
   id: string;
@@ -74,6 +81,16 @@ function FieldCard({
           placeholder={field.type === 'currency' ? '$' : '0'}
           value={value === '' ? '' : typeof value === 'number' ? value : value || ''}
           onChange={(e) => onChange(field.id, e.target.value === '' ? '' : Number(e.target.value))}
+        />
+      );
+
+    if (field.type === 'date')
+      return (
+        <input
+          type="date"
+          className="w-full rounded-lg border border-slate-200 bg-white/70 p-2 focus:outline-none focus:ring-2 focus:ring-sky-400"
+          value={typeof value === 'string' ? value : value ?? ''}
+          onChange={(e) => onChange(field.id, e.target.value)}
         />
       );
 
@@ -455,6 +472,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
                   <option value="select">select</option>
                   <option value="multiselect">multiselect</option>
                   <option value="currency">currency</option>
+                  <option value="date">date</option>
                   <option value="note">note</option>
                 </select>
               </div>

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient';
 import type { User } from '@supabase/supabase-js';
+import { randomUUID } from 'crypto';
 
 type Profile = { user: User; org_id: string; role: string };
 
@@ -45,6 +46,98 @@ export async function createTemplate(name: string, fields: any[]) {
     .single();
   if (error) throw new Error(error.message);
   return data;
+}
+
+export async function ensureDefaultTemplates(orgId: string) {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('No logueado');
+
+  const { data: existing, error: existingErr } = await supabase
+    .from('templates')
+    .select('name')
+    .eq('org_id', orgId)
+    .in('name', ['IB', 'Trader']);
+  if (existingErr) throw new Error(existingErr.message);
+  const names = existing?.map((t) => t.name) || [];
+
+  const inserts: any[] = [];
+  if (!names.includes('IB')) {
+    inserts.push({
+      org_id: orgId,
+      name: 'IB',
+      fields: [
+        { id: randomUUID(), label: '¿Qué tan grande es su Comunidad?', type: 'text', x: 1, y: 1, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Tiene un equipo de trabajo? ¿Cuántas personas?', type: 'text', x: 6, y: 1, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Cómo funciona su Comunidad? (Nuevos clientes)', type: 'text', x: 1, y: 3, w: 10, h: 2 },
+        { id: randomUUID(), label: '¿Qué broker utiliza actualmente?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué tipo de instrumentos tradea?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
+        { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 6, y: 7, w: 5, h: 2 },
+        { id: randomUUID(), label: 'Estimación/plan de crecimiento', type: 'text', x: 1, y: 9, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué le interesa o está buscando?', type: 'text', x: 6, y: 9, w: 5, h: 2 },
+        { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 11, w: 5, h: 2 },
+        { id: randomUUID(), label: 'Notas de la conversación', type: 'text', x: 1, y: 13, w: 10, h: 3 },
+      ],
+      created_by: user.id,
+    });
+  }
+
+  if (!names.includes('Trader')) {
+    inserts.push({
+      org_id: orgId,
+      name: 'Trader',
+      fields: [
+        {
+          id: randomUUID(),
+          label: 'Red social de contacto inicial',
+          type: 'multiselect',
+          options: ['Instagram', 'Facebook', 'Telegram', 'LinkedIn', 'Kick', 'TikTok', 'Página oficial', 'Pipeline', 'Referido'],
+          x: 1,
+          y: 1,
+          w: 10,
+          h: 2,
+        },
+        { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 1, y: 3, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué instrumentos maneja?', type: 'text', x: 6, y: 3, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Cuánto tiempo lleva operando?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué broker utiliza?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Cuánto invierte regularmente?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Cuántos lotes mueve al mes?', type: 'text', x: 6, y: 7, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Cuál es tu estrategia de trading?', type: 'text', x: 1, y: 9, w: 10, h: 2 },
+        { id: randomUUID(), label: '¿Qué indicadores o alertas utiliza?', type: 'text', x: 1, y: 11, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 11, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Hace copytrading?', type: 'text', x: 1, y: 13, w: 5, h: 2 },
+        { id: randomUUID(), label: '¿Qué otras herramientas usa? (bots / IA)', type: 'text', x: 6, y: 13, w: 5, h: 2 },
+        {
+          id: randomUUID(),
+          label: 'Intereses',
+          type: 'multiselect',
+          options: ['Educación en trading', 'Mejores herramientas', 'Facilidad para operar', 'Velocidad de respuesta', 'Nuevas estrategias', 'Copytrading'],
+          x: 1,
+          y: 15,
+          w: 10,
+          h: 2,
+        },
+        { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 17, w: 5, h: 2 },
+      ],
+      created_by: user.id,
+    });
+  }
+
+  if (inserts.length) {
+    const { error: insertErr } = await supabase.from('templates').insert(inserts);
+    if (insertErr) throw new Error(insertErr.message);
+  }
+
+  const { data: final, error: finalErr } = await supabase
+    .from('templates')
+    .select('id,name,fields,created_at')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: true });
+  if (finalErr) throw new Error(finalErr.message);
+  return final;
 }
 
 export async function createClient(name: string, tag: string) {


### PR DESCRIPTION
## Summary
- support new `date` field type with calendar input
- seed default IB and Trader templates per org via `ensureDefaultTemplates`
- trigger default template seeding when dashboard mounts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdf5945bfc83318f1567c515d25a35