### PR TITLE
feat: seed default templates and render templates list

### DIFF
--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -3,21 +3,28 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
+import { ensureDefaultTemplates, fetchTemplates, getMyProfile } from '@/lib/db';
 
 export default function TemplatesPage() {
   const router = useRouter();
   const [ready, setReady] = useState(false);
+  const [templates, setTemplates] = useState<any[]>([]);
 
   useEffect(() => {
     let active = true;
-    supabase.auth.getUser().then(({ data }: any) => {
-      if (!active) return;
+    (async () => {
+      const { data } = await supabase.auth.getUser();
       if (!data.user) {
         router.replace('/login');
-      } else {
-        setReady(true);
+        return;
       }
-    });
+      const { org_id } = await getMyProfile();
+      await ensureDefaultTemplates(org_id);
+      const rows = await fetchTemplates();
+      if (!active) return;
+      setTemplates(rows);
+      setReady(true);
+    })();
     return () => {
       active = false;
     };
@@ -36,7 +43,24 @@ export default function TemplatesPage() {
       <Sidebar />
       <main className="flex-1 p-6">
         <h1 className="text-xl font-semibold text-slate-800">Plantillas</h1>
-        <p className="mt-4 text-slate-600">Próximamente…</p>
+        {templates.length === 0 ? (
+          <p className="mt-4 text-slate-600">Aún no hay plantillas.</p>
+        ) : (
+          <div className="mt-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {templates.map((t) => (
+              <div key={t.id} className="rounded-2xl border border-slate-200 bg-white p-4">
+                <div className="font-medium text-slate-800">{t.name}</div>
+                <div className="mt-1 text-xs text-slate-500">{t.fields.length} campos</div>
+                <button
+                  className="mt-3 text-sm text-sky-700 hover:underline"
+                  onClick={() => router.push(`/home?template=${t.id}`)}
+                >
+                  Usar en ficha
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </main>
     </div>
   );

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -49,95 +49,76 @@ export async function createTemplate(name: string, fields: any[]) {
 }
 
 export async function ensureDefaultTemplates(orgId: string) {
+  const { count, error: countErr } = await supabase
+    .from('templates')
+    .select('id', { count: 'exact', head: true })
+    .eq('org_id', orgId);
+  if (countErr) throw new Error(countErr.message);
+  if ((count ?? 0) > 0) return;
+
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) throw new Error('No logueado');
 
-  const { data: existing, error: existingErr } = await supabase
+  const ibFields = [
+    { id: randomUUID(), label: '¿Qué tan grande es su Comunidad?', type: 'text', x: 1, y: 1, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Tiene un equipo de trabajo? ¿Cuántas personas?', type: 'text', x: 6, y: 1, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Cómo funciona su Comunidad? (Nuevos clientes)', type: 'text', x: 1, y: 3, w: 10, h: 2 },
+    { id: randomUUID(), label: '¿Qué broker utiliza actualmente?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué tipo de instrumentos tradea?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
+    { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 6, y: 7, w: 5, h: 2 },
+    { id: randomUUID(), label: 'Estimación/plan de crecimiento', type: 'text', x: 1, y: 9, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué le interesa o está buscando?', type: 'text', x: 6, y: 9, w: 5, h: 2 },
+    { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 11, w: 5, h: 2 },
+    { id: randomUUID(), label: 'Notas de la conversación', type: 'note', x: 1, y: 13, w: 10, h: 3 },
+  ];
+
+  const traderFields = [
+    {
+      id: randomUUID(),
+      label: 'Red social de contacto inicial',
+      type: 'multiselect',
+      options: ['Instagram', 'Facebook', 'Telegram', 'LinkedIn', 'Kick', 'TikTok', 'Página oficial', 'Pipeline', 'Referido'],
+      x: 1,
+      y: 1,
+      w: 10,
+      h: 2,
+    },
+    { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 1, y: 3, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué instrumentos maneja?', type: 'text', x: 6, y: 3, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Cuánto tiempo lleva operando?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué broker utiliza?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Cuánto invierte regularmente?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Cuántos lotes mueve al mes?', type: 'text', x: 6, y: 7, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Cuál es tu estrategia de trading?', type: 'text', x: 1, y: 9, w: 10, h: 2 },
+    { id: randomUUID(), label: '¿Qué indicadores o alertas utiliza?', type: 'text', x: 1, y: 11, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 11, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Hace copytrading?', type: 'text', x: 1, y: 13, w: 5, h: 2 },
+    { id: randomUUID(), label: '¿Qué otras herramientas usa? (bots / IA)', type: 'text', x: 6, y: 13, w: 5, h: 2 },
+    {
+      id: randomUUID(),
+      label: 'Intereses',
+      type: 'multiselect',
+      options: ['Educación en trading', 'Mejores herramientas', 'Facilidad para operar', 'Velocidad de respuesta', 'Nuevas estrategias', 'Copytrading'],
+      x: 1,
+      y: 15,
+      w: 10,
+      h: 2,
+    },
+    { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 17, w: 5, h: 2 },
+  ];
+
+  const rows = [
+    { org_id: orgId, name: 'IB', fields: ibFields, created_by: user.id },
+    { org_id: orgId, name: 'Trader', fields: traderFields, created_by: user.id },
+  ];
+
+  const { error: insertErr } = await supabase
     .from('templates')
-    .select('name')
-    .eq('org_id', orgId)
-    .in('name', ['IB', 'Trader']);
-  if (existingErr) throw new Error(existingErr.message);
-  const names = existing?.map((t) => t.name) || [];
-
-  const inserts: any[] = [];
-  if (!names.includes('IB')) {
-    inserts.push({
-      org_id: orgId,
-      name: 'IB',
-      fields: [
-        { id: randomUUID(), label: '¿Qué tan grande es su Comunidad?', type: 'text', x: 1, y: 1, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Tiene un equipo de trabajo? ¿Cuántas personas?', type: 'text', x: 6, y: 1, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Cómo funciona su Comunidad? (Nuevos clientes)', type: 'text', x: 1, y: 3, w: 10, h: 2 },
-        { id: randomUUID(), label: '¿Qué broker utiliza actualmente?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué tipo de instrumentos tradea?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
-        { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 6, y: 7, w: 5, h: 2 },
-        { id: randomUUID(), label: 'Estimación/plan de crecimiento', type: 'text', x: 1, y: 9, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué le interesa o está buscando?', type: 'text', x: 6, y: 9, w: 5, h: 2 },
-        { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 11, w: 5, h: 2 },
-        { id: randomUUID(), label: 'Notas de la conversación', type: 'text', x: 1, y: 13, w: 10, h: 3 },
-      ],
-      created_by: user.id,
-    });
-  }
-
-  if (!names.includes('Trader')) {
-    inserts.push({
-      org_id: orgId,
-      name: 'Trader',
-      fields: [
-        {
-          id: randomUUID(),
-          label: 'Red social de contacto inicial',
-          type: 'multiselect',
-          options: ['Instagram', 'Facebook', 'Telegram', 'LinkedIn', 'Kick', 'TikTok', 'Página oficial', 'Pipeline', 'Referido'],
-          x: 1,
-          y: 1,
-          w: 10,
-          h: 2,
-        },
-        { id: randomUUID(), label: 'Datos de contacto (celular y correo)', type: 'text', x: 1, y: 3, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué instrumentos maneja?', type: 'text', x: 6, y: 3, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Cuánto tiempo lleva operando?', type: 'text', x: 1, y: 5, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué broker utiliza?', type: 'text', x: 6, y: 5, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Cuánto invierte regularmente?', type: 'text', x: 1, y: 7, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Cuántos lotes mueve al mes?', type: 'text', x: 6, y: 7, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Cuál es tu estrategia de trading?', type: 'text', x: 1, y: 9, w: 10, h: 2 },
-        { id: randomUUID(), label: '¿Qué indicadores o alertas utiliza?', type: 'text', x: 1, y: 11, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué plataforma utiliza para tradear?', type: 'text', x: 6, y: 11, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Hace copytrading?', type: 'text', x: 1, y: 13, w: 5, h: 2 },
-        { id: randomUUID(), label: '¿Qué otras herramientas usa? (bots / IA)', type: 'text', x: 6, y: 13, w: 5, h: 2 },
-        {
-          id: randomUUID(),
-          label: 'Intereses',
-          type: 'multiselect',
-          options: ['Educación en trading', 'Mejores herramientas', 'Facilidad para operar', 'Velocidad de respuesta', 'Nuevas estrategias', 'Copytrading'],
-          x: 1,
-          y: 15,
-          w: 10,
-          h: 2,
-        },
-        { id: randomUUID(), label: 'Siguiente fecha de follow up', type: 'date', x: 1, y: 17, w: 5, h: 2 },
-      ],
-      created_by: user.id,
-    });
-  }
-
-  if (inserts.length) {
-    const { error: insertErr } = await supabase.from('templates').insert(inserts);
-    if (insertErr) throw new Error(insertErr.message);
-  }
-
-  const { data: final, error: finalErr } = await supabase
-    .from('templates')
-    .select('id,name,fields,created_at')
-    .eq('org_id', orgId)
-    .order('created_at', { ascending: true });
-  if (finalErr) throw new Error(finalErr.message);
-  return final;
+    .insert(rows, { onConflict: 'org_id,name' });
+  if (insertErr) throw new Error(insertErr.message);
 }
 
 export async function createClient(name: string, tag: string) {

--- a/lib/uid.ts
+++ b/lib/uid.ts
@@ -1,0 +1,5 @@
+import { randomUUID } from 'crypto';
+
+export function uid(): string {
+  return randomUUID();
+}


### PR DESCRIPTION
## Summary
- seed "IB" and "Trader" templates for new orgs
- show available templates with field count and quick use link
- refactor uid helper to use ES module import without unnecessary ts comment

## Testing
- `npm test` *(fails: command not found: npm)*
- `npm run lint` *(fails: command not found: npm)*
- `npm run build` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf8e63d708331b463c1752ee5c3e3