### PR TITLE
feat: auto-save client answers

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -192,6 +192,17 @@ export async function saveClientRecord(clientId: string, templateId: string, ans
   return data.id as string;
 }
 
+export async function fetchLatestRecord(clientId: string) {
+  const { data, error } = await supabase
+    .from('client_records')
+    .select('answers, template_id, score, matches, created_at')
+    .eq('client_id', clientId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(error.message);
+  return data && data[0] ? data[0] : null;
+}
+
 export async function fetchNotes(clientId: string) {
   const { data, error } = await supabase.from('notes')
     .select('id, field_id, text, created_at, created_by')


### PR DESCRIPTION
## Summary
- auto-save client answers on the board and save before leaving
- add manual **Guardar cambios** button for client pages
- support loading previously saved answers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be05eb3b388331a8c922aab0d4bb2a