### PR TITLE
Improve template upsert and add debounced autosave

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -224,6 +224,11 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const [notes, setNotesState] = useState<Record<string, Note[]>>({});
   const lastSavedRef = useRef('');
   const [saving, setSaving] = useState(false);
+  const [autoMsg, setAutoMsg] = useState('');
+  const latestAnswers = useRef<Answers>({});
+  useEffect(() => {
+    latestAnswers.current = answers;
+  }, [answers]);
 
   const [noteField, setNoteField] = useState<string | null>(null);
   const [zoom, setZoom] = useState(1);
@@ -311,8 +316,11 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
         const score = recs.reduce((s, r) => s + r.score, 0);
         await saveClientRecord(clientId, tpl.id, answers, score, recs);
         lastSavedRef.current = current;
-      } catch (err) {
-        console.error(err);
+        setAutoMsg('Guardado');
+      } catch (err: any) {
+        console.error('save error', err);
+        setAutoMsg(err.message || 'Error al guardar');
+        throw err;
       } finally {
         setSaving(false);
       }
@@ -321,15 +329,24 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   );
 
   useEffect(() => {
-    const id = setInterval(() => {
-      save();
-    }, 5000);
-    return () => clearInterval(id);
-  }, [save]);
+    if (!clientId || !tpl?.id) return;
+    const h = setTimeout(async () => {
+      const current = JSON.stringify(latestAnswers.current);
+      if (current === lastSavedRef.current) return;
+      try {
+        await save();
+        setAutoMsg('Guardado automático');
+      } catch (e) {
+        console.warn('Autosave error', e);
+        setAutoMsg('No se pudo auto-guardar');
+      }
+    }, 700);
+    return () => clearTimeout(h);
+  }, [answers, clientId, tpl?.id, save]);
 
   useEffect(() => {
     const handler = () => {
-      save(true);
+      save(true).catch(() => {});
       supabase.auth.signOut().catch(() => {});
     };
     window.addEventListener('beforeunload', handler);
@@ -428,11 +445,18 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           />
           <button
             className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-60"
-            onClick={() => save(true)}
-            disabled={saving}
+            onClick={async () => {
+              try {
+                await save(true);
+              } catch (err: any) {
+                alert(err.message || 'Error al guardar');
+              }
+            }}
+            disabled={saving || !clientId || !tpl}
           >
             {saving ? 'Guardando…' : 'Guardar cambios'}
           </button>
+          {autoMsg && <span className="text-sm text-slate-600">{autoMsg}</span>}
           <button
             className="px-3 py-1.5 rounded-xl border border-red-200 text-red-600 hover:bg-red-50"
             onClick={async () => {


### PR DESCRIPTION
## Summary
- upsert templates with org scope and log results
- add payload/error logging when saving client records
- add debounced autosave with UI feedback and manual save error handling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be337d2e388331997b498a924010ed