### PR TITLE
Bootstrap user profile and org after auth

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import { ensureProfileAndOrg } from '@/lib/bootstrap';
 
 type Mode = 'login' | 'signup';
 
@@ -22,6 +23,11 @@ export default function LoginPage() {
     (async () => {
       const { data } = await supabase.auth.getSession();
       if (!cancelled && data.session) {
+        try {
+          await ensureProfileAndOrg();
+        } catch (e) {
+          console.error(e);
+        }
         router.replace('/dashboard');
       } else if (!cancelled) {
         setReady(true);
@@ -42,6 +48,7 @@ export default function LoginPage() {
         const { data, error } = await supabase.auth.signUp({ email, password: pass });
         if (error) throw error;
         if (data.session) {
+          await ensureProfileAndOrg();
           router.replace('/dashboard');
           return;
         }
@@ -49,6 +56,7 @@ export default function LoginPage() {
         const { data, error } = await supabase.auth.signInWithPassword({ email, password: pass });
         if (error) throw error;
         if (data.session) {
+          await ensureProfileAndOrg();
           router.replace('/dashboard');
           return;
         }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
+import { ensureProfileAndOrg } from '@/lib/bootstrap';
 
 export default function Signup() {
   const router = useRouter();
@@ -21,7 +22,10 @@ export default function Signup() {
     const { data, error: inErr } = await supabase.auth.signInWithPassword({ email, password: pass });
     if (inErr) return setMsg('❌ ' + inErr.message);
 
-    if (data.session) router.replace('/dashboard');
+    if (data.session) {
+      await ensureProfileAndOrg();
+      router.replace('/dashboard');
+    }
   }
 
   return (

--- a/lib/bootstrap.ts
+++ b/lib/bootstrap.ts
@@ -1,0 +1,42 @@
+import { supabase } from '@/lib/supabaseClient';
+import { ensureDefaultTemplates } from '@/lib/db';
+
+export async function ensureProfileAndOrg() {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('No session');
+
+  // ¿Ya hay profile?
+  const { data: prof, error: pErr } = await supabase
+    .from('profiles')
+    .select('user_id, org_id')
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (pErr) throw pErr;
+  if (prof?.org_id) {
+    await ensureDefaultTemplates(prof.org_id);
+    return prof.org_id;
+  }
+
+  // Crear org propia para este usuario (o unir a una existente si tienes invitaciones)
+  const { data: orgRow, error: oErr } = await supabase
+    .from('orgs')
+    .insert({ name: user.email || 'Mi organización' })
+    .select('id')
+    .single();
+  if (oErr) throw oErr;
+
+  const orgId = orgRow.id as string;
+
+  // Crear profile
+  const { error: iErr } = await supabase
+    .from('profiles')
+    .insert({ user_id: user.id, org_id: orgId, role: 'member' });
+  if (iErr) throw iErr;
+
+  // Sembrar plantillas base si no hay
+  await ensureDefaultTemplates(orgId);
+  return orgId;
+}


### PR DESCRIPTION
## Summary
- add `ensureProfileAndOrg` to create profile/org and seed default templates
- call bootstrap after login or signup before redirecting to dashboard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef003c6b08331babe3314458bccc4