### PR TITLE
feat: template management with inline editor

### DIFF
--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,20 +1,44 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type CSSProperties } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
-import { ensureDefaultTemplates, fetchTemplates, getMyProfile } from '@/lib/db';
+import {
+  ensureDefaultTemplates,
+  fetchTemplates,
+  getMyProfile,
+  createTemplate,
+  updateTemplateFields,
+} from '@/lib/db';
+import { uid } from '@/lib/uid';
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { SortableContext, arrayMove, useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 export default function TemplatesPage() {
   const router = useRouter();
   const [ready, setReady] = useState(false);
   const [templates, setTemplates] = useState<any[]>([]);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [editingTpl, setEditingTpl] = useState<any | null>(null);
+  const [fields, setFields] = useState<any[]>([]);
+  const [tplDirty, setTplDirty] = useState(false);
+  const [fieldModalOpen, setFieldModalOpen] = useState(false);
+  const [fieldLabel, setFieldLabel] = useState('');
+  const [fieldType, setFieldType] = useState('text');
+  const [fieldOptions, setFieldOptions] = useState('');
+  const [editingFieldId, setEditingFieldId] = useState<string | null>(null);
+
+  const sensors = useSensors(useSensor(PointerSensor));
 
   useEffect(() => {
     let active = true;
     (async () => {
-      const { data } = await supabase.auth.getUser();
-      if (!data.user) {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
         router.replace('/login');
         return;
       }
@@ -42,7 +66,15 @@ export default function TemplatesPage() {
     <div className="min-h-screen bg-slate-50 flex">
       <Sidebar />
       <main className="flex-1 p-6">
-        <h1 className="text-xl font-semibold text-slate-800">Plantillas</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-semibold text-slate-800">Plantillas</h1>
+          <button
+            className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700"
+            onClick={() => setShowCreate(true)}
+          >
+            Crear Plantilla
+          </button>
+        </div>
         {templates.length === 0 ? (
           <p className="mt-4 text-slate-600">Aún no hay plantillas.</p>
         ) : (
@@ -53,15 +85,249 @@ export default function TemplatesPage() {
                 <div className="mt-1 text-xs text-slate-500">{t.fields.length} campos</div>
                 <button
                   className="mt-3 text-sm text-sky-700 hover:underline"
-                  onClick={() => router.push(`/home?template=${t.id}`)}
+                  onClick={() => {
+                    setEditingTpl(t);
+                    setFields(t.fields || []);
+                    setTplDirty(false);
+                  }}
                 >
-                  Usar en ficha
+                  Editar
                 </button>
               </div>
             ))}
           </div>
         )}
+        {editingTpl && (
+          <div className="mt-8">
+            <h2 className="text-lg font-medium text-slate-800 mb-4">Editando: {editingTpl.name}</h2>
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={({ active, over }) => {
+                if (over && active.id !== over.id) {
+                  setFields((items) => {
+                    const oldIndex = items.findIndex((i) => i.id === active.id);
+                    const newIndex = items.findIndex((i) => i.id === over.id);
+                    return arrayMove(items, oldIndex, newIndex);
+                  });
+                  setTplDirty(true);
+                }
+              }}
+            >
+              <SortableContext items={fields.map((f) => f.id)}>
+                <div className="flex flex-col gap-2">
+                  {fields.map((f) => (
+                    <FieldItem
+                      key={f.id}
+                      field={f}
+                      onEdit={() => {
+                        setEditingFieldId(f.id);
+                        setFieldLabel(f.label);
+                        setFieldType(f.type);
+                        setFieldOptions((f.options || []).join(', '));
+                        setFieldModalOpen(true);
+                      }}
+                      onDelete={() => {
+                        setFields((prev) => prev.filter((x) => x.id !== f.id));
+                        setTplDirty(true);
+                      }}
+                    />
+                  ))}
+                </div>
+              </SortableContext>
+            </DndContext>
+            <div className="mt-4 flex gap-2">
+              <button
+                className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+                onClick={() => {
+                  setEditingFieldId(null);
+                  setFieldLabel('');
+                  setFieldType('text');
+                  setFieldOptions('');
+                  setFieldModalOpen(true);
+                }}
+              >
+                Agregar pregunta
+              </button>
+              <button
+                className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-50"
+                disabled={!tplDirty}
+                onClick={async () => {
+                  await updateTemplateFields(editingTpl.id, fields);
+                  setTemplates((prev) =>
+                    prev.map((t) => (t.id === editingTpl.id ? { ...t, fields } : t))
+                  );
+                  setEditingTpl({ ...editingTpl, fields });
+                  setTplDirty(false);
+                }}
+              >
+                Guardar cambios
+              </button>
+            </div>
+          </div>
+        )}
       </main>
+      {showCreate && (
+        <div className="fixed inset-0 bg-black/50 grid place-items-center">
+          <div className="bg-white rounded-2xl p-4 w-full max-w-sm">
+            <h2 className="text-lg font-medium mb-2">Nueva plantilla</h2>
+            <input
+              className="w-full border border-slate-200 rounded-lg p-2"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+                onClick={() => {
+                  setShowCreate(false);
+                  setNewName('');
+                }}
+              >
+                Cancelar
+              </button>
+              <button
+                className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700"
+                onClick={async () => {
+                  if (!newName.trim()) return;
+                  const tpl = await createTemplate(newName.trim(), []);
+                  setTemplates((prev) => [tpl, ...prev]);
+                  setShowCreate(false);
+                  setNewName('');
+                }}
+              >
+                Crear
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+      {fieldModalOpen && (
+        <div className="fixed inset-0 bg-black/50 grid place-items-center">
+          <div className="bg-white rounded-2xl p-4 w-full max-w-md">
+            <h2 className="text-lg font-medium mb-2">
+              {editingFieldId ? 'Editar pregunta' : 'Nueva pregunta'}
+            </h2>
+            <div className="flex flex-col gap-2">
+              <div className="flex flex-col gap-1">
+                <label className="text-sm text-slate-600">Label</label>
+                <input
+                  className="rounded-lg border border-slate-200 p-2"
+                  value={fieldLabel}
+                  onChange={(e) => setFieldLabel(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-sm text-slate-600">Tipo</label>
+                <select
+                  className="rounded-lg border border-slate-200 p-2"
+                  value={fieldType}
+                  onChange={(e) => setFieldType(e.target.value)}
+                >
+                  <option value="text">text</option>
+                  <option value="number">number</option>
+                  <option value="select">select</option>
+                  <option value="multiselect">multiselect</option>
+                  <option value="currency">currency</option>
+                  <option value="date">date</option>
+                  <option value="note">note</option>
+                </select>
+              </div>
+              {(fieldType === 'select' || fieldType === 'multiselect') && (
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm text-slate-600">
+                    Opciones (separadas por coma)
+                  </label>
+                  <textarea
+                    className="rounded-lg border border-slate-200 p-2"
+                    value={fieldOptions}
+                    onChange={(e) => setFieldOptions(e.target.value)}
+                  />
+                </div>
+              )}
+            </div>
+            <div className="flex justify-end gap-2 mt-4">
+              <button
+                className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+                onClick={() => setFieldModalOpen(false)}
+              >
+                Cancelar
+              </button>
+              <button
+                className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700"
+                onClick={() => {
+                  if (!fieldLabel.trim()) return;
+                  const opts =
+                    fieldType === 'select' || fieldType === 'multiselect'
+                      ? fieldOptions.split(',').map((s) => s.trim()).filter(Boolean)
+                      : undefined;
+                  if (editingFieldId) {
+                    setFields((prev) =>
+                      prev.map((f) =>
+                        f.id === editingFieldId
+                          ? { ...f, label: fieldLabel.trim(), type: fieldType, ...(opts ? { options: opts } : { options: undefined }) }
+                          : f
+                      )
+                    );
+                  } else {
+                    setFields((prev) => [
+                      ...prev,
+                      {
+                        id: uid(),
+                        label: fieldLabel.trim(),
+                        type: fieldType,
+                        ...(opts ? { options: opts } : {}),
+                      },
+                    ]);
+                  }
+                  setTplDirty(true);
+                  setFieldModalOpen(false);
+                }}
+              >
+                Guardar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FieldItem({
+  field,
+  onEdit,
+  onDelete,
+}: {
+  field: any;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: field.id });
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="rounded-2xl border border-slate-200 bg-white p-4 flex justify-between items-start"
+    >
+      <div>
+        <div className="font-medium text-slate-800">{field.label}</div>
+        <div className="text-xs text-slate-500">{field.type}</div>
+      </div>
+      <div className="flex gap-2 text-sm">
+        <button className="text-sky-700 hover:underline" onClick={onEdit}>
+          Editar
+        </button>
+        <button className="text-rose-600 hover:underline" onClick={onDelete}>
+          Eliminar
+        </button>
+      </div>
     </div>
   );
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -196,6 +196,10 @@ export async function upsertTemplateFields(templateId: string, fields: any[]) {
   return data;
 }
 
+export async function updateTemplateFields(templateId: string, fields: any[]) {
+  return upsertTemplateFields(templateId, fields);
+}
+
 export async function saveClientRecord(
   clientId: string,
   templateId: string,


### PR DESCRIPTION
## Summary
- protect templates route by checking auth session
- add UI to create templates and edit existing ones
- support drag-and-drop question editing and save via updateTemplateFields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef0443b248331ac00b8843eddae67