### PR TITLE
feat: enable drag-and-drop question ordering

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -19,6 +19,14 @@ import { computeRecommendations } from '@/lib/recommendations';
 import { uid } from '@/lib/uid';
 import { fetchClient } from '@/lib/clients';
 import type { ClientRow } from '@/lib/clients';
+import { DndContext, DragEndEvent, closestCenter } from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 
 type FieldType =
   | 'text'
@@ -194,6 +202,22 @@ const FieldCard = memo(function FieldCard({
   );
 });
 
+const SortableFieldCard = (
+  props: React.ComponentProps<typeof FieldCard>,
+) => {
+  const { field } = props;
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: field.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      <FieldCard {...props} />
+    </div>
+  );
+};
+
 export default function HomePage({ searchParams }: { searchParams: { client?: string } }) {
   const router = useRouter();
   // Protección de ruta: esperamos conocer la sesión antes de renderizar el dashboard
@@ -236,6 +260,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const [zoom, setZoom] = useState(1);
 
   const [tplMenuOpen, setTplMenuOpen] = useState(false);
+  const [editLayout, setEditLayout] = useState(false);
   const [addFieldOpen, setAddFieldOpen] = useState(false);
   const [newLabel, setNewLabel] = useState('');
   const [newType, setNewType] = useState<FieldType>('text');
@@ -243,6 +268,23 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const [recsOpen, setRecsOpen] = useState(true);
 
   const unsub = useRef<(() => void) | null>(null);
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (active.id !== over?.id) {
+      setTpl((prev) => {
+        if (!prev) return prev;
+        const oldIndex = prev.fields.findIndex((f) => f.id === active.id);
+        const newIndex = prev.fields.findIndex((f) => f.id === over?.id);
+        const newFields = arrayMove(prev.fields, oldIndex, newIndex).map((f, idx) => ({
+          ...f,
+          y: idx + 1,
+        }));
+        return { ...prev, fields: newFields };
+      });
+      setTplDirty(true);
+    }
+  };
 
   useEffect(() => {
     if (searchParams?.client) setClientId(searchParams.client);
@@ -534,6 +576,12 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           >
             Agregar pregunta
           </button>
+          <button
+            className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
+            onClick={() => setEditLayout((o) => !o)}
+          >
+            {editLayout ? 'Terminar orden' : 'Editar orden'}
+          </button>
         </div>
       </div>
 
@@ -543,23 +591,47 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           style={{ ...corkBg }}
         >
           <div
-            className="grid gap-3"
-            style={{
-              gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
-              transform: `scale(${zoom})`,
-              transformOrigin: 'top left',
-            }}
+            className={editLayout ? 'space-y-3' : 'grid gap-3'}
+            style={
+              editLayout
+                ? undefined
+                : {
+                    gridTemplateColumns: `repeat(${gridCols}, minmax(0, 1fr))`,
+                    transform: `scale(${zoom})`,
+                    transformOrigin: 'top left',
+                  }
+            }
           >
-            {tpl?.fields.map((f) => (
-              <FieldCard
-                key={f.id}
-                field={f}
-                value={answers[f.id]}
-                onChange={updateAnswer}
-                notes={notes[f.id] || []}
-                onAddNote={(id) => setNoteField(id)}
-              />
-            ))}
+            {editLayout ? (
+              <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                <SortableContext
+                  items={tpl?.fields.map((f) => f.id) || []}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {tpl?.fields.map((f) => (
+                    <SortableFieldCard
+                      key={f.id}
+                      field={f}
+                      value={answers[f.id]}
+                      onChange={updateAnswer}
+                      notes={notes[f.id] || []}
+                      onAddNote={(id) => setNoteField(id)}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+            ) : (
+              tpl?.fields.map((f) => (
+                <FieldCard
+                  key={f.id}
+                  field={f}
+                  value={answers[f.id]}
+                  onChange={updateAnswer}
+                  notes={notes[f.id] || []}
+                  onAddNote={(id) => setNoteField(id)}
+                />
+              ))
+            )}
           </div>
           <button
             onClick={() => setRecsOpen((o) => !o)}

--- a/app/templates/editor/page.tsx
+++ b/app/templates/editor/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { useState } from 'react';
+import Sidebar from '@/components/Sidebar';
+import { DndContext, closestCenter, DragEndEvent } from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  useSortable,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+type Question = { id: string; text: string };
+
+function SortableQuestion({ question }: { question: Question }) {
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: question.id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="p-3 rounded-xl border border-slate-200 bg-white shadow-sm"
+    >
+      {question.text}
+    </div>
+  );
+}
+
+export default function TemplateEditorPage() {
+  const [questions, setQuestions] = useState<Question[]>([
+    { id: '1', text: 'Pregunta 1' },
+    { id: '2', text: 'Pregunta 2' },
+    { id: '3', text: 'Pregunta 3' },
+  ]);
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (active.id !== over?.id) {
+      setQuestions((items) => {
+        const oldIndex = items.findIndex((i) => i.id === active.id);
+        const newIndex = items.findIndex((i) => i.id === over?.id);
+        return arrayMove(items, oldIndex, newIndex);
+      });
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex">
+      <Sidebar />
+      <main className="flex-1 p-6">
+        <h1 className="text-xl font-semibold text-slate-800">Editor de plantilla</h1>
+        <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={questions.map((q) => q.id)} strategy={verticalListSortingStrategy}>
+            <div className="mt-6 space-y-3">
+              {questions.map((q) => (
+                <SortableQuestion key={q.id} question={q} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow reordering template questions via drag-and-drop
- reuse sortable logic on home page when editing layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bef04f44888331b9088898daa5fb82