### PR TITLE
Sort template fields before saving

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -319,31 +319,6 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
 
   const unsub = useRef<(() => void) | null>(null);
 
-  const handleDragEnd = useCallback(
-    (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (active.id !== over?.id) {
-        setTpl((prev) => {
-          if (!prev) return prev;
-          const oldIndex = prev.fields.findIndex((f) => f.id === active.id);
-          const newIndex = prev.fields.findIndex((f) => f.id === over?.id);
-          let nextY = 1;
-          const newFields = arrayMove<Field>(prev.fields, oldIndex, newIndex).map(
-            (f: Field) => {
-              const updated = { ...f, y: nextY };
-              nextY += f.h;
-              return updated;
-            },
-          );
-          return { ...prev, fields: newFields };
-        });
-        setTplDirty(true);
-        save();
-      }
-    },
-    [save],
-  );
-
   useEffect(() => {
     if (searchParams?.client) setClientId(searchParams.client);
   }, [searchParams?.client]);
@@ -469,6 +444,31 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
       alert(`Error al guardar: ${e.message}`);
     }
   }, [save]);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (active.id !== over?.id) {
+        setTpl((prev) => {
+          if (!prev) return prev;
+          const oldIndex = prev.fields.findIndex((f) => f.id === active.id);
+          const newIndex = prev.fields.findIndex((f) => f.id === over?.id);
+          let nextY = 1;
+          const newFields = arrayMove<Field>(prev.fields, oldIndex, newIndex).map(
+            (f: Field) => {
+              const updated = { ...f, y: nextY };
+              nextY += f.h;
+              return updated;
+            },
+          );
+          return { ...prev, fields: newFields };
+        });
+        setTplDirty(true);
+        save();
+      }
+    },
+    [save],
+  );
 
   useEffect(() => {
     if (!clientId || !tpl?.id) return;

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -153,11 +153,14 @@ export default function TemplatesPage() {
                 className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-50"
                 disabled={!tplDirty}
                 onClick={async () => {
-                  await updateTemplateFields(editingTpl.id, fields);
+                  const sortedFields = fields.slice().sort((a, b) => a.y - b.y);
+                  await updateTemplateFields(editingTpl.id, sortedFields);
                   setTemplates((prev) =>
-                    prev.map((t) => (t.id === editingTpl.id ? { ...t, fields } : t))
+                    prev.map((t) =>
+                      t.id === editingTpl.id ? { ...t, fields: sortedFields } : t
+                    )
                   );
-                  setEditingTpl({ ...editingTpl, fields });
+                  setEditingTpl({ ...editingTpl, fields: sortedFields });
                   setTplDirty(false);
                 }}
               >

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -34,7 +34,12 @@ export async function fetchTemplates() {
     .eq('org_id', org_id)
     .order('created_at', { ascending: false });
   if (error) throw new Error(error.message);
-  return data;
+  return (data || []).map((tpl: any) => ({
+    ...tpl,
+    fields: (tpl.fields || [])
+      .slice()
+      .sort((a: any, b: any) => a.y - b.y),
+  }));
 }
 
 export async function createTemplate(name: string, fields: any[]) {


### PR DESCRIPTION
## Summary
- Sort template fields by position when fetching and selecting templates
- Save immediately after drag reordering and persist sorted fields
- Ensure template updates pass ordered fields

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf8fb0240c833190f59ca7d5b0b58d