### PR TITLE
feat: add react-grid-layout for field board

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@supabase/supabase-js": "^2.56.1",
     "next": "15.5.2",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-grid-layout": "^1.5.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/types/react-grid-layout.d.ts
+++ b/types/react-grid-layout.d.ts
@@ -1,0 +1,38 @@
+declare module 'react-grid-layout' {
+  import * as React from 'react';
+
+  export interface Layout {
+    i: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    minW?: number;
+    minH?: number;
+    maxW?: number;
+    maxH?: number;
+    static?: boolean;
+    isDraggable?: boolean;
+    isResizable?: boolean;
+  }
+
+  export interface ReactGridLayoutProps {
+    className?: string;
+    style?: React.CSSProperties;
+    layout: Layout[];
+    cols?: number;
+    rowHeight?: number;
+    width?: number;
+    margin?: [number, number];
+    isDraggable?: boolean;
+    isResizable?: boolean;
+    compactType?: 'vertical' | 'horizontal' | null;
+    onLayoutChange?: (layout: Layout[]) => void;
+    draggableHandle?: string;
+    [key: string]: any;
+  }
+
+  export default class ReactGridLayout extends React.Component<ReactGridLayoutProps> {}
+  export function WidthProvider<P>(component: React.ComponentType<P>): React.ComponentClass<P>;
+  export type { Layout as LayoutItem };
+}


### PR DESCRIPTION
## Summary
- add react-grid-layout dependency
- migrate client board to react-grid-layout with drag and resize
- persist field coordinates on layout changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf92721bd48331b1e50f9dfaf849a1