### PR TITLE
Remove redundant edit order button

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -641,16 +641,10 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           >
             Agregar pregunta
           </button>
-          <button
-            className="px-3 py-1.5 rounded-xl border bg-white hover:bg-slate-50"
-            onClick={() => setEditLayout((o) => !o)}
-          >
-            {editLayout ? 'Terminar orden' : 'Editar orden'}
-          </button>
+          </div>
         </div>
-      </div>
 
-      <div className="mx-auto max-w-[1400px] px-4 py-6 grid grid-cols-12 gap-4">
+        <div className="mx-auto max-w-[1400px] px-4 py-6 grid grid-cols-12 gap-4">
         <div
           className={`${recsOpen ? 'col-span-9' : 'col-span-12'} relative rounded-3xl p-4 border border-slate-200 shadow-sm transition-all duration-300`}
           style={{ ...corkBg }}


### PR DESCRIPTION
## Summary
- Remove duplicated "Editar orden" button from home page so layout editing is handled only by "Editar layout" button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf984324088331b797e4a7257ae8fe