### PR TITLE
feat: store client-specific layout

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -314,6 +314,28 @@ export async function upsertClientFieldLayout(
   if (error) throw new Error(error.message);
 }
 
+export type ClientLayoutItem = { id: string; x: number; y: number; w: number; h: number };
+
+export async function fetchClientLayout(clientId: string): Promise<ClientLayoutItem[]> {
+  const { data, error } = await supabase
+    .from('client_layouts')
+    .select('layout')
+    .eq('client_id', clientId)
+    .maybeSingle();
+  if (error) throw new Error(error.message);
+  return (data?.layout as any[]) || [];
+}
+
+export async function saveClientLayout(
+  clientId: string,
+  layout: ClientLayoutItem[],
+): Promise<void> {
+  const { error } = await supabase
+    .from('client_layouts')
+    .upsert({ client_id: clientId, layout }, { onConflict: 'client_id' });
+  if (error) throw new Error(error.message);
+}
+
 export async function deleteClient(clientId: string) {
   const { error: notesError } = await supabase.from('notes').delete().eq('client_id', clientId);
   if (notesError) throw new Error(notesError.message);

--- a/supabase/migrations/20240411000000_client_layouts.sql
+++ b/supabase/migrations/20240411000000_client_layouts.sql
@@ -1,0 +1,4 @@
+create table if not exists client_layouts (
+  client_id uuid primary key references clients(id) on delete cascade,
+  layout jsonb not null default '[]'::jsonb
+);


### PR DESCRIPTION
## Summary
- add `client_layouts` table for saving field positions per client
- load and merge client layout on home page
- persist client layout instead of mutating template definitions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0356dfa9c83319feab6dff4642915