### PR TITLE
Store per-field client layout overrides

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -314,28 +314,6 @@ export async function upsertClientFieldLayout(
   if (error) throw new Error(error.message);
 }
 
-export type ClientLayoutItem = { id: string; x: number; y: number; w: number; h: number };
-
-export async function fetchClientLayout(clientId: string): Promise<ClientLayoutItem[]> {
-  const { data, error } = await supabase
-    .from('client_layouts')
-    .select('layout')
-    .eq('client_id', clientId)
-    .maybeSingle();
-  if (error) throw new Error(error.message);
-  return (data?.layout as any[]) || [];
-}
-
-export async function saveClientLayout(
-  clientId: string,
-  layout: ClientLayoutItem[],
-): Promise<void> {
-  const { error } = await supabase
-    .from('client_layouts')
-    .upsert({ client_id: clientId, layout }, { onConflict: 'client_id' });
-  if (error) throw new Error(error.message);
-}
-
 export async function deleteClient(clientId: string) {
   const { error: notesError } = await supabase.from('notes').delete().eq('client_id', clientId);
   if (notesError) throw new Error(notesError.message);

--- a/supabase/migrations/20240501000000_client_field_overrides_layout.sql
+++ b/supabase/migrations/20240501000000_client_field_overrides_layout.sql
@@ -1,0 +1,5 @@
+alter table client_field_overrides
+  add column if not exists x int,
+  add column if not exists y int,
+  add column if not exists w int,
+  add column if not exists h int;


### PR DESCRIPTION
## Summary
- add nullable x/y/w/h to client_field_overrides table
- persist layout overrides with upsertClientFieldLayout
- update home page to read/write layout positions per field

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c052e9e40083318eab94fa1b2dddcd