### PR TITLE
Limit client fetch by organization

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -28,7 +28,7 @@ export default function DashboardPage() {
       try {
         const { org_id } = await getMyProfile();
         await ensureDefaultTemplates(org_id);
-        const rows = await fetchClients();
+        const rows = await fetchClients({ orgId: org_id });
         setClients(rows);
       } catch (e: any) {
         setMsg(e?.message ?? 'No se pudieron cargar las fichas');

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -2,10 +2,22 @@ import { supabase } from './supabaseClient';
 
 export type ClientRow = { id: string; name: string; tag: string; created_at: string };
 
-export async function fetchClients(): Promise<ClientRow[]> {
-  const { data, error } = await supabase
+export async function fetchClients({
+  orgId,
+  userId,
+}: {
+  orgId?: string;
+  userId?: string;
+} = {}): Promise<ClientRow[]> {
+  let query = supabase
     .from('clients')
-    .select('id,name,tag,created_at')
+    .select('id,name,tag,created_at');
+
+  if (orgId) query = query.eq('org_id', orgId);
+  else if (userId) query = query.eq('created_by', userId);
+
+  const { data, error } = await query
+    .limit(50)
     .order('created_at', { ascending: false });
   if (error) throw new Error(error.message);
   return data ?? [];


### PR DESCRIPTION
## Summary
- allow filtering clients by organization or creator and limit results to 50
- retrieve organization id on dashboard and pass it to client fetch

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c0e409be0883318c7dbe650775131c