### PR TITLE
Add skeleton and retry error handling on dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabaseClient';
 import Sidebar from '@/components/Sidebar';
@@ -15,7 +15,20 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [clients, setClients] = useState<ClientRow[]>([]);
   const [msg, setMsg] = useState<string | null>(null);
+  const [orgId, setOrgId] = useState<string | null>(null);
   const [openCreate, setOpenCreate] = useState(false);
+
+  const loadClients = useCallback(async (oId: string) => {
+    try {
+      const rows = await fetchClients({ orgId: oId });
+      setClients(rows);
+      setMsg(null);
+    } catch (e: any) {
+      setMsg(e?.message ?? 'No se pudieron cargar las fichas');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -27,16 +40,22 @@ export default function DashboardPage() {
       setEmail(data.user.email ?? null);
       try {
         const { org_id } = await getMyProfile();
+        setOrgId(org_id);
         await ensureDefaultTemplates(org_id);
-        const rows = await fetchClients({ orgId: org_id });
-        setClients(rows);
+        await loadClients(org_id);
       } catch (e: any) {
         setMsg(e?.message ?? 'No se pudieron cargar las fichas');
-      } finally {
         setLoading(false);
       }
     })();
-  }, [router]);
+  }, [router, loadClients]);
+
+  async function onRetry() {
+    if (!orgId) return;
+    setMsg(null);
+    setLoading(true);
+    await loadClients(orgId);
+  }
 
   async function onCreate(name: string, tag: string) {
     const id = await createClient(name, tag);
@@ -70,10 +89,20 @@ export default function DashboardPage() {
             </div>
           </div>
 
-          {msg && <p className="mt-3 text-sm text-rose-600">{msg}</p>}
+          {msg && (
+            <div className="mt-3 rounded-lg border border-rose-200 bg-rose-50 p-4 text-rose-700">
+              <p className="text-sm">{msg}</p>
+              <button
+                className="mt-3 rounded bg-rose-600 px-3 py-1 text-sm text-white hover:bg-rose-700"
+                onClick={onRetry}
+              >
+                Reintentar
+              </button>
+            </div>
+          )}
 
           {loading ? (
-            <div className="mt-8 text-slate-600">Cargando…</div>
+            <ClientsSkeleton />
           ) : clients.length === 0 ? (
             <div className="mt-8 text-slate-600">Aún no hay fichas. Crea la primera.</div>
           ) : (
@@ -101,5 +130,21 @@ export default function DashboardPage() {
         onCreate={onCreate}
       />
     </>
+  );
+}
+
+function ClientsSkeleton() {
+  return (
+    <div className="mt-6 grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {[...Array(4)].map((_, i) => (
+        <div
+          key={i}
+          className="rounded-2xl border border-slate-200 bg-white p-4 animate-pulse"
+        >
+          <div className="h-4 w-3/4 rounded bg-slate-200" />
+          <div className="mt-2 h-3 w-1/2 rounded bg-slate-200" />
+        </div>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- show client card skeletons while loading
- display error block with retry button
- allow retry to refetch clients using org id

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0e4ebba188331a5a8a6cb8c21e44e