### PR TITLE
Use drag/resize stop events for layout persistence

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -499,7 +499,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
     }
   }, [save]);
 
-  const handleLayoutChange = useCallback(
+  const applyLayoutChanges = useCallback(
     (layout: Layout[]) => {
       const normalized = compactType ? normalizeLayout(layout, gridCols) : layout;
       setTpl((prev) => {
@@ -729,7 +729,8 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
               rowHeight={80}
               isDraggable={editLayout}
               isResizable={editLayout}
-              onLayoutChange={handleLayoutChange}
+              onDragStop={applyLayoutChanges}
+              onResizeStop={applyLayoutChanges}
               draggableHandle=".drag-handle"
               compactType={compactType}
               margin={[12, 12]}


### PR DESCRIPTION
## Summary
- replace onLayoutChange with onDragStop/onResizeStop on the home layout grid
- persist template layout using a shared applyLayoutChanges handler with existing debounce

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c0e5a82d688331a6148db4f92eef63