### PR TITLE
Add template switcher with merged answers

### DIFF
--- a/lib/answers.ts
+++ b/lib/answers.ts
@@ -1,0 +1,16 @@
+export function mergeAnswers(
+  prevAnswers: Record<string, any>,
+  currentAnswers: Record<string, any>,
+  fields: { id: string }[],
+): Record<string, any> {
+  const ids = new Set(fields.map((f) => f.id));
+  const out: Record<string, any> = {};
+  ids.forEach((id) => {
+    if (Object.prototype.hasOwnProperty.call(currentAnswers, id)) {
+      out[id] = currentAnswers[id];
+    } else if (Object.prototype.hasOwnProperty.call(prevAnswers, id)) {
+      out[id] = prevAnswers[id];
+    }
+  });
+  return out;
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -56,6 +56,21 @@ export async function fetchTemplates() {
   }));
 }
 
+export async function fetchTemplate(tplId: string) {
+  const { data, error } = await supabase
+    .from('templates')
+    .select('id,name,fields,created_at')
+    .eq('id', tplId)
+    .single();
+  if (error) throw new Error(error.message);
+  return {
+    ...data,
+    fields: (data?.fields || [])
+      .slice()
+      .sort((a: any, b: any) => a.y - b.y),
+  } as any;
+}
+
 export async function createTemplate(name: string, fields: any[]) {
   const {
     data: { user },
@@ -261,6 +276,18 @@ export async function fetchLatestRecord(clientId: string) {
     .from('client_records')
     .select('answers, template_id, score, matches, created_at')
     .eq('client_id', clientId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(error.message);
+  return data && data[0] ? data[0] : null;
+}
+
+export async function fetchLastClientRecord(clientId: string, tplId: string) {
+  const { data, error } = await supabase
+    .from('client_records')
+    .select('answers, template_id, score, matches, created_at')
+    .eq('client_id', clientId)
+    .eq('template_id', tplId)
     .order('created_at', { ascending: false })
     .limit(1);
   if (error) throw new Error(error.message);


### PR DESCRIPTION
## Summary
- load individual templates and client records on demand
- merge previous answers with current ones when switching templates
- show spinner and disable controls while template is switching

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc')
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ed6776e88331a86f1d704ffa0b4f