### PR TITLE
feat: normalize template data

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -38,6 +38,7 @@ import {
   normalizeLayout,
 } from '@/lib/layout';
 import { mergeAnswers } from '@/lib/answers';
+import { normalizeTemplate } from '@/lib/types';
 
 const ReactGridLayout = WidthProvider(GridLayout);
 
@@ -456,7 +457,9 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
 
       setClient(c);
 
-      const sorted: Template[] = (list as Template[]).map((t) => sortTplFields(t));
+      const sorted: Template[] = (list as Template[]).map((t) =>
+        sortTplFields(normalizeTemplate(t)),
+      );
       setTemplates(sorted);
 
       let chosen: Template | null = sorted.length ? sorted[0] : null;
@@ -496,7 +499,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
         setHiddenFields([]);
       }
 
-      if (chosen) setTpl(sortTplFields(chosen as any));
+      if (chosen) setTpl(sortTplFields(normalizeTemplate(chosen as any)));
 
       const byField: Record<string, Note[]> = {};
       (notesList as any).forEach((n: any) => {
@@ -526,7 +529,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           fetchTemplate(tplId),
           fetchLastClientRecord(clientId, tplId),
         ]);
-        const sorted = sortTplFields(tplData as any);
+        const sorted = sortTplFields(normalizeTemplate(tplData as any));
         setTpl(sorted);
         setTemplates((prev) =>
           prev.map((t) => (t.id === sorted.id ? sorted : t)),

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabaseClient';
 import type { User } from '@supabase/supabase-js';
 import { uid } from './uid';
+import { normalizeTemplate } from './types';
 
 type Profile = { user: User; org_id: string; role: string };
 
@@ -48,12 +49,14 @@ export async function fetchTemplates() {
     }
     throw new Error(error.message);
   }
-  return (data || []).map((tpl: any) => ({
-    ...tpl,
-    fields: (tpl.fields || [])
-      .slice()
-      .sort((a: any, b: any) => a.y - b.y),
-  }));
+  return (data || []).map((tpl: any) =>
+    normalizeTemplate({
+      ...tpl,
+      fields: (tpl.fields || [])
+        .slice()
+        .sort((a: any, b: any) => a.y - b.y),
+    }),
+  );
 }
 
 export async function fetchTemplate(tplId: string) {
@@ -63,12 +66,12 @@ export async function fetchTemplate(tplId: string) {
     .eq('id', tplId)
     .single();
   if (error) throw new Error(error.message);
-  return {
+  return normalizeTemplate({
     ...data,
     fields: (data?.fields || [])
       .slice()
       .sort((a: any, b: any) => a.y - b.y),
-  } as any;
+  } as any);
 }
 
 export async function createTemplate(name: string, fields: any[]) {


### PR DESCRIPTION
## Summary
- add `normalizeTemplate` utility with validation, deduplication and default geometry
- sanitize template results in `fetchTemplates` and `fetchTemplate`
- defensively normalize templates when switching in home page

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c0f1cc70808331b6d463d3acf106db