### PR TITLE
feat: add field ordering

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -58,6 +58,7 @@ type Field = {
   options?: string[];
   x: number;
   y: number;
+  order: number;
   /** Width in grid columns. Defaults to DEFAULT_W. */
   w?: number;
   /** Height in grid rows. Defaults to DEFAULT_H. */
@@ -75,7 +76,7 @@ type Note = { id: string; field_id: string; text: string; created_at?: string; c
 
 const sortTplFields = (tpl: Template): Template => ({
   ...tpl,
-  fields: tpl.fields.slice().sort((a, b) => a.y - b.y),
+  fields: tpl.fields.slice().sort((a, b) => a.order - b.order),
 });
 
 function debounce<T extends (...args: any[]) => void>(fn: T, delay: number) {
@@ -614,6 +615,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
                           y: ov.y ?? f.y,
                           w: ov.w ?? f.w,
                           h: ov.h ?? f.h,
+                          order: ov.order ?? f.order,
                         }
                       : f;
                   }),
@@ -1031,6 +1033,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
               y: maxY + 1,
               w: DEFAULT_W,
               h: DEFAULT_H,
+              order: tpl?.fields.length ?? 0,
             };
             setTpl((prev) =>
               prev ? { ...prev, fields: [...prev.fields, field] } : prev,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -70,7 +70,11 @@ export async function fetchTemplates() {
       ...tpl,
       fields: (tpl.fields || [])
         .slice()
-        .sort((a: any, b: any) => a.y - b.y),
+        .sort((a: any, b: any) =>
+          typeof a.order === 'number' && typeof b.order === 'number'
+            ? a.order - b.order
+            : (a.y - b.y),
+        ),
     }),
   );
   console.debug('fetchTemplates end', {
@@ -93,7 +97,11 @@ export async function fetchTemplate(tplId: string) {
     ...data,
     fields: (data?.fields || [])
       .slice()
-      .sort((a: any, b: any) => a.y - b.y),
+      .sort((a: any, b: any) =>
+        typeof a.order === 'number' && typeof b.order === 'number'
+          ? a.order - b.order
+          : (a.y - b.y),
+      ),
   } as any);
   console.debug('fetchTemplate end', { tplId, fieldsCount: tpl.fields.length });
   return tpl;
@@ -385,7 +393,7 @@ export async function addNote(clientId: string, fieldId: string, text: string) {
 export async function fetchClientFieldOverrides(clientId: string) {
   const { data, error } = await supabase
     .from('client_field_overrides')
-    .select('field_id, hidden, x, y, w, h')
+    .select('field_id, hidden, x, y, w, h, order')
     .eq('client_id', clientId);
   if (error) throw new Error(error.message);
   return (data as any[]) || [];
@@ -395,7 +403,16 @@ export async function hideFieldForClient(clientId: string, fieldId: string) {
   const { error } = await supabase
     .from('client_field_overrides')
     .upsert(
-      { client_id: clientId, field_id: fieldId, hidden: true, x: null, y: null, w: null, h: null },
+      {
+        client_id: clientId,
+        field_id: fieldId,
+        hidden: true,
+        x: null,
+        y: null,
+        w: null,
+        h: null,
+        order: null,
+      },
       { onConflict: 'client_id,field_id' }
     );
   if (error) throw new Error(error.message);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,8 @@ export type Field = {
   options?: string[];
   x: number;
   y: number;
+  /** Display order starting at 0. */
+  order: number;
   /** Width in grid columns. Defaults to DEFAULT_W. */
   w?: number;
   /** Height in grid rows. Defaults to DEFAULT_H. */
@@ -40,6 +42,7 @@ export type ClientFieldOverride = {
   y?: number | null;
   w?: number | null;
   h?: number | null;
+  order?: number | null;
   hidden?: boolean | null;
   label_override?: string | null;
   type_override?: FieldType | null;
@@ -94,6 +97,7 @@ export function normalizeTemplate(t: unknown): Template {
     const y = typeof raw.y === 'number' && raw.y >= 1 ? raw.y : DEFAULT_FIELD_POS.y;
     const w = typeof raw.w === 'number' && raw.w >= 1 ? raw.w : DEFAULT_FIELD_POS.w;
     const h = typeof raw.h === 'number' && raw.h >= 1 ? raw.h : DEFAULT_FIELD_POS.h;
+    const order = typeof raw.order === 'number' && raw.order >= 0 ? raw.order : fields.length;
 
     const field: Field = {
       id,
@@ -101,6 +105,7 @@ export function normalizeTemplate(t: unknown): Template {
       type: raw.type,
       x,
       y,
+      order,
       w,
       h,
     };
@@ -109,9 +114,14 @@ export function normalizeTemplate(t: unknown): Template {
       if (Array.isArray(raw.options)) field.options = raw.options.slice();
     }
 
-    Object.freeze(field);
     fields.push(field);
   }
+
+  fields.sort((a, b) => a.order - b.order);
+  fields.forEach((f, idx) => {
+    f.order = idx;
+    Object.freeze(f);
+  });
 
   Object.freeze(fields);
 


### PR DESCRIPTION
## Summary
- track field order within templates and client overrides
- normalize and default field ordering
- render and create fields with explicit order

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c36c6644bc83319872b55bbe1e0b56