### PR TITLE
feat: confirm deletions and update field order

### DIFF
--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -128,7 +128,11 @@ export default function TemplatesPage() {
                         setFieldModalOpen(true);
                       }}
                       onDelete={() => {
-                        setFields((prev) => prev.filter((x) => x.id !== f.id));
+                        if (!confirm('¿Eliminar esta pregunta?')) return;
+                        setFields((prev) => {
+                          const filtered = prev.filter((x) => x.id !== f.id);
+                          return filtered.map((fld, idx) => ({ ...fld, order: idx }));
+                        });
                         setTplDirty(true);
                       }}
                     />
@@ -168,6 +172,7 @@ export default function TemplatesPage() {
                     )
                   );
                   setEditingTpl({ ...editingTpl, fields: ordered });
+                  setFields(ordered);
                   setTplDirty(false);
                 }}
               >


### PR DESCRIPTION
## Summary
- prompt for confirmation before removing a template field
- renumber remaining fields after deletion and mark as dirty
- persist updated ordering to state and database when saving

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c36f593838833193282fedc3a60371