### PR TITLE
feat: add client type and template selection

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -57,10 +57,10 @@ export default function DashboardPage() {
     await loadClients(orgId);
   }
 
-  async function onCreate(name: string, tag: string) {
-    console.debug('createClient start', { name, tag });
+  async function onCreate(name: string, tag: string, templateId: string) {
+    console.debug('createClient start', { name, tag, templateId });
     try {
-      const id = await createClient(name, tag);
+      const id = await createClient(name, tag, templateId);
       console.debug('createClient success', { id });
       router.replace(`/home?client=${id}`);
     } catch (e: any) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -216,8 +216,12 @@ export async function ensureDefaultTemplates(orgId: string) {
   if (insertErr) throw new Error(insertErr.message);
 }
 
-export async function createClient(name: string, tag: string) {
-  console.debug('createClient start', { nameLength: name.length, tagLength: tag.length });
+export async function createClient(name: string, tag: string, templateId: string) {
+  console.debug('createClient start', {
+    nameLength: name.length,
+    tagLength: tag.length,
+    templateId,
+  });
   // 1) usuario actual
   const { data: u, error: eu } = await supabase.auth.getUser();
   if (eu) throw new Error(eu.message);
@@ -243,10 +247,21 @@ export async function createClient(name: string, tag: string) {
     .single();
 
   if (error) throw new Error(error.message);
+  if (templateId) {
+    const { error: recErr } = await supabase.from('client_records').insert({
+      client_id: data.id,
+      template_id: templateId,
+      answers: {},
+      score: 0,
+      matches: [],
+    });
+    if (recErr) throw new Error(recErr.message);
+  }
   console.debug('createClient end', {
     id: data.id,
     nameLength: name.length,
     tagLength: tag.length,
+    templateId,
   });
   return data.id as string;
 }


### PR DESCRIPTION
## Summary
- replace lead status options with Trader, IB, Fund Manager, and Regional
- allow selecting a template when creating a client
- store initial template choice with new client records

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm install` *(fails: 403 Forbidden when fetching react-grid-layout)*

------
https://chatgpt.com/codex/tasks/task_e_68c37e82ec8c833188ef9aad4753f4f9