### PR TITLE
feat: enable field drag, drop, and resize in client view

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,28 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.react-resizable-handle {
+  display: none;
+}
+
+.react-resizable-handle.custom-resize-handle {
+  display: block;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 16px;
+  height: 16px;
+  cursor: se-resize;
+}
+
+.react-resizable-handle.custom-resize-handle:after {
+  content: '';
+  position: absolute;
+  right: 3px;
+  bottom: 3px;
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid #94a3b8;
+  border-bottom: 2px solid #94a3b8;
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -259,21 +259,24 @@ const FieldCard = memo(function FieldCard({
   return (
     <div className="relative h-full rounded-2xl shadow-sm border border-slate-200 bg-white/80 backdrop-blur p-3 flex flex-col gap-2">
       {editLayout && (
-        <div className="absolute -left-4 top-2 flex flex-col gap-1">
-          <button
-            className="p-1 text-rose-600 hover:text-rose-700"
-            onClick={onDelete}
-            disabled={disabled}
-          >
-            <XIcon className="w-4 h-4" />
-          </button>
-          <button
-            className="drag-handle p-1 text-slate-400 hover:text-slate-600 cursor-grab"
-            disabled={disabled}
-          >
-            <GripIcon className="w-4 h-4" />
-          </button>
-        </div>
+        <>
+          <div className="absolute -left-4 top-2 flex flex-col gap-1">
+            <button
+              className="p-1 text-rose-600 hover:text-rose-700"
+              onClick={onDelete}
+              disabled={disabled}
+            >
+              <XIcon className="w-4 h-4" />
+            </button>
+            <button
+              className="drag-handle p-1 text-slate-400 hover:text-slate-600 cursor-grab"
+              disabled={disabled}
+            >
+              <GripIcon className="w-4 h-4" />
+            </button>
+          </div>
+          <span className="react-resizable-handle custom-resize-handle" />
+        </>
       )}
       <div className="flex items-center justify-between">
         <div className="font-semibold text-slate-800">{field.label}</div>


### PR DESCRIPTION
## Summary
- show drag handle and delete controls while editing client layout
- add visible resize handle for each field
- style custom resizable handle and hide default

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68c391cbb9fc8331a6e3e1cd96519f68