### PR TITLE
feat(home): move scripts to right sidebar with selector + remove bottom scripts

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -132,6 +132,16 @@ export async function fetchScripts(): Promise<Script[]> {
   return (data as Script[]) || [];
 }
 
+export async function fetchScriptsForOrg(orgId: string): Promise<Script[]> {
+  const { data, error } = await supabase
+    .from('scripts')
+    .select('id, org_id, title, content, created_by, created_at, updated_at')
+    .eq('org_id', orgId)
+    .order('created_at', { ascending: false });
+  if (error) throw error;
+  return (data as Script[]) || [];
+}
+
 export async function createScript(title: string, content: string): Promise<Script> {
   const { user, org_id } = await getMyProfile();
   const { data, error } = await supabase


### PR DESCRIPTION
## Summary
- add fetchScriptsForOrg helper
- move scripts into right sidebar with dropdown selector and scrollable content
- persist selected script per client and remove bottom scripts section

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f987aae4833190af454a670c6102