### PR TITLE
Add client confidence slider and badge

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -23,6 +23,8 @@ import {
 import ModalText from '@/components/ModalText';
 import QuestionModal from '@/components/QuestionModal';
 import ModalAlert from '@/components/ModalAlert';
+import ConfidenceBadge from '@/components/ConfidenceBadge';
+import ConfidenceCard from '@/components/ConfidenceCard';
 import { subscribeClientLive } from '@/lib/realtime';
 import { computeRecommendations } from '@/lib/recommendations';
 import { fetchClient, updateClientName } from '@/lib/clients';
@@ -388,6 +390,8 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const [questionModalOpen, setQuestionModalOpen] = useState(false);
   const [editingField, setEditingField] = useState<Field | null>(null);
   const [recsOpen, setRecsOpen] = useState(true);
+  const [confidenceScore, setConfidenceScore] = useState(50);
+  const [confidenceNote, setConfidenceNote] = useState('');
 
   const [layoutSaved, setLayoutSaved] = useState(false);
   const layoutSaveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -487,6 +491,8 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
   const loadAll = useCallback(async () => {
     if (!clientId) {
       if (mounted.current) setClient(null);
+      setConfidenceScore(50);
+      setConfidenceNote('');
       return;
     }
     if (!mounted.current) return;
@@ -503,6 +509,8 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
 
       if (!mounted.current) return;
       setClient(c);
+      setConfidenceScore(c?.confidence_score ?? 50);
+      setConfidenceNote(c?.confidence_note ?? '');
 
       const sorted: Template[] = (list as Template[]).map((t) =>
         sortTplFields(normalizeTemplate(t)),
@@ -929,6 +937,7 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
           >
             {editLayout ? 'Listo' : 'Editar layout'}
           </button>
+          <ConfidenceBadge score={confidenceScore} />
           <button
             className="px-3 py-1.5 rounded-xl bg-sky-600 text-white hover:bg-sky-700 disabled:opacity-60"
             onClick={onSaveClick}
@@ -1084,6 +1093,8 @@ export default function HomePage({ searchParams }: { searchParams: { client?: st
                 ))}
               </div>
             </div>
+
+            <ConfidenceCard clientId={clientId} score={confidenceScore} note={confidenceNote} onScoreChange={setConfidenceScore} onNoteChange={setConfidenceNote} />
 
             <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
               <h3 className="font-semibold text-slate-800">Guiones</h3>

--- a/components/ConfidenceBadge.tsx
+++ b/components/ConfidenceBadge.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { scoreToFace, scoreToColor } from '@/lib/confidence';
+
+export default function ConfidenceBadge({ score }: { score: number }) {
+  const color = scoreToColor(score);
+  const face = scoreToFace(score);
+  return (
+    <div className="flex items-center gap-1" title="Probabilidad de cierre">
+      <span className="text-xl" aria-hidden style={{ color }}>
+        {face}
+      </span>
+      <span
+        className="px-2 py-0.5 rounded-full text-sm text-white"
+        style={{ backgroundColor: color }}
+      >
+        {score}%
+      </span>
+    </div>
+  );
+}

--- a/components/ConfidenceCard.tsx
+++ b/components/ConfidenceCard.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import { updateClientConfidence } from '@/lib/db';
+import { scoreToColor, scoreToChip } from '@/lib/confidence';
+
+interface Props {
+  clientId: string;
+  score: number;
+  note: string;
+  onScoreChange: (s: number) => void;
+  onNoteChange: (n: string) => void;
+}
+
+export default function ConfidenceCard({
+  clientId,
+  score,
+  note,
+  onScoreChange,
+  onNoteChange,
+}: Props) {
+  const [status, setStatus] = useState<'saved' | 'saving' | 'error'>('saved');
+  const saveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const first = useRef(true);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    if (saveRef.current) clearTimeout(saveRef.current);
+    setStatus('saving');
+    saveRef.current = setTimeout(async () => {
+      try {
+        await updateClientConfidence(clientId, score, note);
+        setStatus('saved');
+      } catch (err) {
+        console.error(err);
+        setStatus('error');
+      }
+    }, 600);
+    return () => {
+      if (saveRef.current) clearTimeout(saveRef.current);
+    };
+  }, [clientId, score, note]);
+
+  const color = scoreToColor(score);
+  const chip = scoreToChip(score);
+
+  const handleKey = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+      e.preventDefault();
+      const delta = e.shiftKey ? 10 : 1;
+      let next = score + (e.key === 'ArrowRight' ? delta : -delta);
+      next = Math.max(0, Math.min(100, next));
+      onScoreChange(next);
+    }
+  };
+
+  return (
+    <div className="rounded-3xl bg-white shadow-sm border border-slate-200 p-4">
+      <h3 className="font-semibold text-slate-800 mb-2">Probabilidad</h3>
+      <input
+        type="range"
+        min={0}
+        max={100}
+        step={1}
+        value={score}
+        onChange={(e) => onScoreChange(Number(e.target.value))}
+        aria-label="Probabilidad de cierre"
+        onKeyDown={handleKey}
+        className="w-full h-2 rounded-lg appearance-none cursor-pointer"
+        style={{ background: 'linear-gradient(to right, #ef4444, #facc15, #22c55e)', accentColor: color }}
+      />
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-2xl font-semibold" style={{ color }}>
+          {score}%
+        </span>
+        <span className={`px-2 py-0.5 rounded-full text-xs ${chip.className}`}>{chip.label}</span>
+      </div>
+      <textarea
+        className="mt-3 w-full rounded-lg border border-slate-200 bg-white p-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400"
+        aria-label="Notas de probabilidad"
+        value={note}
+        onChange={(e) => onNoteChange(e.target.value)}
+      />
+      <div className="mt-2 text-sm text-slate-600">
+        {status === 'saving' && 'Guardando…'}
+        {status === 'saved' && 'Guardado'}
+        {status === 'error' && <span className="text-red-600">Error al guardar</span>}
+      </div>
+    </div>
+  );
+}

--- a/lib/clients.ts
+++ b/lib/clients.ts
@@ -1,7 +1,14 @@
 import { supabase } from './supabaseClient';
 import { getMyProfile } from './db';
 
-export type ClientRow = { id: string; name: string; tag: string; created_at: string };
+export type ClientRow = {
+  id: string;
+  name: string;
+  tag: string;
+  created_at: string;
+  confidence_score: number | null;
+  confidence_note: string | null;
+};
 
 export async function fetchClients({
   orgId,
@@ -12,7 +19,7 @@ export async function fetchClients({
 } = {}): Promise<ClientRow[]> {
   let query = supabase
     .from('clients')
-    .select('id,name,tag,created_at');
+    .select('id,name,tag,created_at,confidence_score,confidence_note');
 
   if (orgId) query = query.eq('org_id', orgId);
   else if (userId) query = query.eq('created_by', userId);
@@ -42,7 +49,7 @@ export async function fetchClients({
 export async function fetchClient(id: string): Promise<ClientRow | null> {
   const { data, error } = await supabase
     .from('clients')
-    .select('id,name,tag,created_at')
+    .select('id,name,tag,created_at,confidence_score,confidence_note')
     .eq('id', id)
     .single();
   if (error) throw new Error(error.message);
@@ -54,7 +61,7 @@ export async function updateClientName(id: string, name: string): Promise<Client
     .from('clients')
     .update({ name })
     .eq('id', id)
-    .select('id,name,tag,created_at')
+    .select('id,name,tag,created_at,confidence_score,confidence_note')
     .single();
   if (error) throw new Error(error.message);
   return data as ClientRow;

--- a/lib/confidence.ts
+++ b/lib/confidence.ts
@@ -1,0 +1,25 @@
+export function scoreToColor(score: number): string {
+  if (score <= 20) return '#ef4444'; // red-500
+  if (score <= 40) return '#f97316'; // orange-500
+  if (score <= 60) return '#facc15'; // yellow-400
+  if (score <= 80) return '#a3e635'; // lime-400
+  return '#22c55e'; // green-500
+}
+
+export function scoreToFace(score: number): string {
+  if (score <= 20) return '😡';
+  if (score <= 40) return '😕';
+  if (score <= 60) return '😐';
+  if (score <= 80) return '🙂';
+  return '😄';
+}
+
+export function scoreToChip(score: number): { label: string; className: string } {
+  if (score < 40) {
+    return { label: 'Rojo', className: 'bg-red-100 text-red-600' };
+  }
+  if (score < 70) {
+    return { label: 'Ámbar', className: 'bg-yellow-100 text-yellow-700' };
+  }
+  return { label: 'Verde', className: 'bg-green-100 text-green-600' };
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -521,6 +521,29 @@ export async function saveClientLayoutOverrides(
   if (error) throw new Error(error.message);
 }
 
+export async function getClientConfidence(clientId: string) {
+  const { data, error } = await supabase
+    .from('clients')
+    .select('confidence_score, confidence_note')
+    .eq('id', clientId)
+    .single();
+  if (error) throw new Error(error.message);
+  return data as { confidence_score: number | null; confidence_note: string | null };
+}
+
+export async function updateClientConfidence(clientId: string, score: number, note?: string) {
+  const payload: any = { confidence_score: score, confidence_updated_at: new Date().toISOString() };
+  if (note !== undefined) payload.confidence_note = note;
+  const { data, error } = await supabase
+    .from('clients')
+    .update(payload)
+    .eq('id', clientId)
+    .select('confidence_score, confidence_note')
+    .single();
+  if (error) throw new Error(error.message);
+  return data as { confidence_score: number | null; confidence_note: string | null };
+}
+
 export async function hideFieldForClient(clientId: string, fieldId: string) {
   await saveClientLayoutOverrides(clientId, {
     [fieldId]: { hidden: true },


### PR DESCRIPTION
## Summary
- add functions to fetch/update client confidence fields
- display confidence slider card with autosave and notes
- show live confidence badge with emoji in top bar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7077738e88331bfc6f9a490dd38da